### PR TITLE
Add visualizers for all prediction operators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
+.vs
 bin
 obj
 *.user
 *.suo
-.vs
+*.layout
+movies
+models

--- a/Bonsai.Sleap.Design/CentroidCollectionVisualizer.cs
+++ b/Bonsai.Sleap.Design/CentroidCollectionVisualizer.cs
@@ -1,0 +1,82 @@
+﻿using Bonsai;
+using Bonsai.Vision.Design;
+using Bonsai.Sleap;
+using Bonsai.Sleap.Design;
+using OpenTK.Graphics;
+using OpenTK.Graphics.OpenGL;
+using System;
+using System.Windows.Forms;
+using System.Collections.Generic;
+
+[assembly: TypeVisualizer(typeof(CentroidCollectionVisualizer), Target = typeof(CentroidCollection))]
+
+namespace Bonsai.Sleap.Design
+{
+    public class CentroidCollectionVisualizer : IplImageVisualizer
+    {
+        CentroidCollection centroids;
+        LabeledImageLayer labeledImage;
+        ToolStripButton drawLabelsButton;
+
+        public bool DrawLabels { get; set; }
+
+        public override void Load(IServiceProvider provider)
+        {
+            base.Load(provider);
+            drawLabelsButton = new ToolStripButton("Draw Labels");
+            drawLabelsButton.CheckState = CheckState.Checked;
+            drawLabelsButton.Checked = DrawLabels;
+            drawLabelsButton.CheckOnClick = true;
+            drawLabelsButton.CheckedChanged += (sender, e) => DrawLabels = drawLabelsButton.Checked;
+            StatusStrip.Items.Add(drawLabelsButton);
+
+            VisualizerCanvas.Load += (sender, e) =>
+            {
+                labeledImage = new LabeledImageLayer();
+                GL.Enable(EnableCap.PointSmooth);
+            };
+        }
+
+        public override void Show(object value)
+        {
+            centroids = (CentroidCollection)value;
+            base.Show(centroids?.Image);
+        }
+
+        protected override void ShowMashup(IList<object> values)
+        {
+            base.ShowMashup(values);
+            if (centroids != null)
+            {
+                if (DrawLabels)
+                {
+                    labeledImage.UpdateLabels(centroids.Image.Size, VisualizerCanvas.Font, (graphics, labelFont) =>
+                    {
+                        DrawingHelper.DrawLabels(graphics, labelFont, centroids);
+                    });
+                }
+                else labeledImage.ClearLabels();
+            }
+        }
+
+        protected override void RenderFrame()
+        {
+            GL.Color4(Color4.White);
+            base.RenderFrame();
+
+            if (centroids != null)
+            {
+                DrawingHelper.SetDrawState(VisualizerCanvas);
+                DrawingHelper.DrawCentroids(centroids);
+                labeledImage.Draw();
+            }
+        }
+
+        public override void Unload()
+        {
+            base.Unload();
+            labeledImage?.Dispose();
+            labeledImage = null;
+        }
+    }
+}

--- a/Bonsai.Sleap.Design/CentroidVisualizer.cs
+++ b/Bonsai.Sleap.Design/CentroidVisualizer.cs
@@ -48,13 +48,14 @@ namespace Bonsai.Sleap.Design
             base.ShowMashup(values);
             if (centroid != null)
             {
-                labeledImage.UpdateLabels(centroid.Image.Size, VisualizerCanvas.Font, (graphics, labelFont) =>
+                if (DrawLabels)
                 {
-                    if (DrawLabels)
+                    labeledImage.UpdateLabels(centroid.Image.Size, VisualizerCanvas.Font, (graphics, labelFont) =>
                     {
                         DrawingHelper.DrawLabels(graphics, labelFont, centroid);
-                    }
-                });
+                    });
+                }
+                else labeledImage.ClearLabels();
             }
         }
 

--- a/Bonsai.Sleap.Design/CentroidVisualizer.cs
+++ b/Bonsai.Sleap.Design/CentroidVisualizer.cs
@@ -1,4 +1,4 @@
-﻿using Bonsai;
+using Bonsai;
 using Bonsai.Vision.Design;
 using Bonsai.Sleap;
 using Bonsai.Sleap.Design;
@@ -79,7 +79,7 @@ namespace Bonsai.Sleap.Design
                 
                 GL.End();
 
-                if (drawLabels)
+                if (drawLabels && !string.IsNullOrEmpty(centroid.Name))
                 {
                     if (labelImage == null || labelImage.Size != centroid.Image.Size)
                     {

--- a/Bonsai.Sleap.Design/CentroidVisualizer.cs
+++ b/Bonsai.Sleap.Design/CentroidVisualizer.cs
@@ -1,17 +1,12 @@
-using Bonsai;
+﻿using Bonsai;
 using Bonsai.Vision.Design;
 using Bonsai.Sleap;
 using Bonsai.Sleap.Design;
-using OpenCV.Net;
-using OpenTK;
 using OpenTK.Graphics;
 using OpenTK.Graphics.OpenGL;
 using System;
-using System.Drawing;
-using System.Drawing.Drawing2D;
-using System.Drawing.Text;
 using System.Windows.Forms;
-using Font = System.Drawing.Font;
+using System.Collections.Generic;
 
 [assembly: TypeVisualizer(typeof(CentroidVisualizer), Target = typeof(Centroid))]
 
@@ -20,94 +15,67 @@ namespace Bonsai.Sleap.Design
     public class CentroidVisualizer : IplImageVisualizer
     {
         Centroid centroid;
-        IplImage labelImage;
-        IplImageTexture labelTexture;
+        LabeledImageLayer labeledImage;
         ToolStripButton drawLabelsButton;
-        Font labelFont;
 
-        public bool LabelCentroidAnchor { get; set; } = false;
+        public bool DrawLabels { get; set; }
 
         public override void Load(IServiceProvider provider)
         {
             base.Load(provider);
-            drawLabelsButton = new ToolStripButton("Label anchor");
+            drawLabelsButton = new ToolStripButton("Draw Label");
             drawLabelsButton.CheckState = CheckState.Checked;
-            drawLabelsButton.Checked = LabelCentroidAnchor;
+            drawLabelsButton.Checked = DrawLabels;
             drawLabelsButton.CheckOnClick = true;
-            drawLabelsButton.CheckedChanged += (sender, e) => LabelCentroidAnchor = drawLabelsButton.Checked;
+            drawLabelsButton.CheckedChanged += (sender, e) => DrawLabels = drawLabelsButton.Checked;
             StatusStrip.Items.Add(drawLabelsButton);
 
             VisualizerCanvas.Load += (sender, e) =>
             {
-                labelTexture = new IplImageTexture();
-                GL.Enable(EnableCap.Blend);
+                labeledImage = new LabeledImageLayer();
                 GL.Enable(EnableCap.PointSmooth);
-                GL.BlendFunc(BlendingFactor.SrcAlpha, BlendingFactor.OneMinusSrcAlpha);
             };
         }
 
         public override void Show(object value)
         {
             centroid = (Centroid)value;
-            if (centroid != null)
-            {
-                base.Show(centroid.Image);
-            }
+            base.Show(centroid?.Image);
         }
 
-        public static Vector2 NormalizePoint(Point2f point, OpenCV.Net.Size imageSize)
+        protected override void ShowMashup(IList<object> values)
         {
-            return new Vector2(
-                (point.X * 2f / imageSize.Width) - 1,
-                -((point.Y * 2f / imageSize.Height) - 1));
+            base.ShowMashup(values);
+            if (centroid != null)
+            {
+                labeledImage.UpdateLabels(centroid.Image.Size, VisualizerCanvas.Font, (graphics, labelFont) =>
+                {
+                    if (DrawLabels)
+                    {
+                        DrawingHelper.DrawLabels(graphics, labelFont, centroid);
+                    }
+                });
+            }
         }
 
         protected override void RenderFrame()
         {
-            var drawLabels = LabelCentroidAnchor;
             GL.Color4(Color4.White);
             base.RenderFrame();
 
             if (centroid != null)
             {
-                GL.PointSize(5 * VisualizerCanvas.Height / 480f);
-                GL.Disable(EnableCap.Texture2D);
-                GL.Begin(PrimitiveType.Points);
-
-                GL.Color3(ColorPalette.GetColor(0));
-                GL.Vertex2(NormalizePoint(centroid.Position, centroid.Image.Size));
-                
-                GL.End();
-
-                if (drawLabels && !string.IsNullOrEmpty(centroid.Name))
-                {
-                    if (labelImage == null || labelImage.Size != centroid.Image.Size)
-                    {
-                        const float LabelFontScale = 0.02f;
-                        labelImage = new IplImage(centroid.Image.Size, IplDepth.U8, 4);
-                        var emSize = VisualizerCanvas.Font.SizeInPoints * (labelImage.Height * LabelFontScale) / VisualizerCanvas.Font.Height;
-                        labelFont = new Font(VisualizerCanvas.Font.FontFamily, emSize);
-                    }
-
-                    labelImage.SetZero();
-                    using (var labelBitmap = new Bitmap(labelImage.Width, labelImage.Height, labelImage.WidthStep, System.Drawing.Imaging.PixelFormat.Format32bppArgb, labelImage.ImageData))
-                    using (var graphics = Graphics.FromImage(labelBitmap))
-                    using (var format = new StringFormat())
-                    {
-                        graphics.TextRenderingHint = TextRenderingHint.AntiAliasGridFit;
-                        graphics.SmoothingMode = SmoothingMode.AntiAlias;
-                        format.Alignment = StringAlignment.Center;
-                        format.LineAlignment = StringAlignment.Center;
-                        
-                        graphics.DrawString(centroid.Name, labelFont, Brushes.White, centroid.Position.X, centroid.Position.Y);
-                    }
-
-                    GL.Color4(Color4.White);
-                    GL.Enable(EnableCap.Texture2D);
-                    labelTexture.Update(labelImage);
-                    labelTexture.Draw();
-                }
+                DrawingHelper.SetDrawState(VisualizerCanvas);
+                DrawingHelper.DrawCentroid(centroid);
+                labeledImage.Draw();
             }
+        }
+
+        public override void Unload()
+        {
+            base.Unload();
+            labeledImage?.Dispose();
+            labeledImage = null;
         }
     }
 }

--- a/Bonsai.Sleap.Design/DrawingHelper.cs
+++ b/Bonsai.Sleap.Design/DrawingHelper.cs
@@ -75,6 +75,17 @@ namespace Bonsai.Sleap.Design
             GL.End();
         }
 
+        public static void DrawCentroids(CentroidCollection centroids)
+        {
+            GL.Begin(PrimitiveType.Points);
+            for (int i = 0; i < centroids.Count; i++)
+            {
+                GL.Color3(ColorPalette.GetColor(i));
+                GL.Vertex2(NormalizePoint(centroids[i].Position, centroids.Image.Size));
+            }
+            GL.End();
+        }
+
         public static void DrawCentroid(Centroid centroid)
         {
             GL.Begin(PrimitiveType.Points);
@@ -101,18 +112,23 @@ namespace Bonsai.Sleap.Design
         {
             for (int i = 0; i < pose.Count; i++)
             {
-                var bodyPart = pose[i];
-                var position = bodyPart.Position;
-                graphics.DrawString(bodyPart.Name, font, Brushes.White, position.X, position.Y);
+                DrawLabels(graphics, font, pose[i]);
             }
         }
 
-        public static void DrawLabels(Graphics graphics, Font font, Centroid centroid)
+        public static void DrawLabels(Graphics graphics, Font font, CentroidCollection centroids)
+        {
+            for (int i = 0; i < centroids.Count; i++)
+            {
+                DrawLabels(graphics, font, centroids[i]);
+            }
+        }
+
+        public static void DrawLabels(Graphics graphics, Font font, BodyPart centroid)
         {
             if (!string.IsNullOrEmpty(centroid.Name))
             {
-                var position = centroid.Position;
-                graphics.DrawString(centroid.Name, font, Brushes.White, position.X, position.Y);
+                graphics.DrawString(centroid.Name, font, Brushes.White, centroid.Position.X, centroid.Position.Y);
             }
         }
     }

--- a/Bonsai.Sleap.Design/DrawingHelper.cs
+++ b/Bonsai.Sleap.Design/DrawingHelper.cs
@@ -1,0 +1,53 @@
+﻿using OpenCV.Net;
+using OpenTK;
+
+namespace Bonsai.Sleap.Design
+{
+    internal static class DrawingHelper
+    {
+        public static Vector2 NormalizePoint(Point2f point, Size imageSize)
+        {
+            return new Vector2(
+                (point.X * 2f / imageSize.Width) - 1,
+              -((point.Y * 2f / imageSize.Height) - 1));
+        }
+
+        public static Point2f[] GetBoundingBox(Pose pose, Size imageSize, float offsetScale)
+        {
+            var minX = float.NaN;
+            var maxX = float.NaN;
+            var minY = float.NaN;
+            var maxY = float.NaN;
+            var unitOffsetX = imageSize.Width * offsetScale;
+            var unitOffsetY = imageSize.Height * offsetScale;
+
+            for (int j = 0; j < pose.Count; j++)
+            {
+                var position = pose[j].Position;
+                if (j == 0)
+                {
+                    minX = maxX = position.X;
+                    minY = maxY = position.Y;
+                }
+
+                minX = position.X < minX ? position.X : minX;
+                maxX = position.X > maxX ? position.X : maxX;
+                minY = position.Y < minY ? position.Y : minY;
+                maxY = position.Y > maxY ? position.Y : maxY;
+            }
+
+            minX -= unitOffsetX;
+            maxX += unitOffsetX;
+            minY -= unitOffsetY;
+            maxY += unitOffsetY;
+
+            var points = new Point2f[] {
+                new Point2f(minX, minY),
+                new Point2f(maxX, minY),
+                new Point2f(maxX, maxY),
+                new Point2f(minX, maxY)
+            };
+            return points;
+        }
+    }
+}

--- a/Bonsai.Sleap.Design/DrawingHelper.cs
+++ b/Bonsai.Sleap.Design/DrawingHelper.cs
@@ -75,6 +75,14 @@ namespace Bonsai.Sleap.Design
             GL.End();
         }
 
+        public static void DrawCentroid(Centroid centroid)
+        {
+            GL.Begin(PrimitiveType.Points);
+            GL.Color3(ColorPalette.GetColor(0));
+            GL.Vertex2(NormalizePoint(centroid.Position, centroid.Image.Size));
+            GL.End();
+        }
+
         public static void DrawBoundingBox(Pose pose, int colorIndex = 0)
         {
             const float BoundingBoxOffset = 0.02f;
@@ -96,6 +104,15 @@ namespace Bonsai.Sleap.Design
                 var bodyPart = pose[i];
                 var position = bodyPart.Position;
                 graphics.DrawString(bodyPart.Name, font, Brushes.White, position.X, position.Y);
+            }
+        }
+
+        public static void DrawLabels(Graphics graphics, Font font, Centroid centroid)
+        {
+            if (!string.IsNullOrEmpty(centroid.Name))
+            {
+                var position = centroid.Position;
+                graphics.DrawString(centroid.Name, font, Brushes.White, position.X, position.Y);
             }
         }
     }

--- a/Bonsai.Sleap.Design/DrawingHelper.cs
+++ b/Bonsai.Sleap.Design/DrawingHelper.cs
@@ -1,5 +1,7 @@
-﻿using OpenCV.Net;
+﻿using Bonsai.Vision.Design;
+using OpenCV.Net;
 using OpenTK;
+using OpenTK.Graphics.OpenGL;
 
 namespace Bonsai.Sleap.Design
 {
@@ -48,6 +50,40 @@ namespace Bonsai.Sleap.Design
                 new Point2f(minX, maxY)
             };
             return points;
+        }
+
+        public static void SetDrawState(VisualizerCanvas canvas)
+        {
+            const float BoundingBoxLineWidth = 3;
+            GL.PointSize(5 * canvas.Height / 480f);
+            GL.LineWidth(BoundingBoxLineWidth);
+            GL.Disable(EnableCap.Texture2D);
+        }
+
+        public static void DrawPose(Pose pose)
+        {
+            GL.Begin(PrimitiveType.Points);
+            for (int i = 0; i < pose.Count; i++)
+            {
+                var position = pose[i].Position;
+                GL.Color3(ColorPalette.GetColor(i));
+                GL.Vertex2(NormalizePoint(position, pose.Image.Size));
+            }
+            GL.End();
+        }
+
+        public static void DrawBoundingBox(Pose pose, int colorIndex = 0)
+        {
+            const float BoundingBoxOffset = 0.02f;
+            var imageSize = pose.Image.Size;
+            var roiLimits = GetBoundingBox(pose, imageSize, BoundingBoxOffset);
+            GL.Color3(ColorPalette.GetColor(colorIndex));
+            GL.Begin(PrimitiveType.LineLoop);
+            for (int i = 0; i < roiLimits.Length; i++)
+            {
+                GL.Vertex2(NormalizePoint(roiLimits[i], imageSize));
+            }
+            GL.End();
         }
     }
 }

--- a/Bonsai.Sleap.Design/DrawingHelper.cs
+++ b/Bonsai.Sleap.Design/DrawingHelper.cs
@@ -2,6 +2,9 @@
 using OpenCV.Net;
 using OpenTK;
 using OpenTK.Graphics.OpenGL;
+using Font = System.Drawing.Font;
+using Graphics = System.Drawing.Graphics;
+using Brushes = System.Drawing.Brushes;
 
 namespace Bonsai.Sleap.Design
 {
@@ -84,6 +87,16 @@ namespace Bonsai.Sleap.Design
                 GL.Vertex2(NormalizePoint(roiLimits[i], imageSize));
             }
             GL.End();
+        }
+
+        public static void DrawLabels(Graphics graphics, Font font, Pose pose)
+        {
+            for (int i = 0; i < pose.Count; i++)
+            {
+                var bodyPart = pose[i];
+                var position = bodyPart.Position;
+                graphics.DrawString(bodyPart.Name, font, Brushes.White, position.X, position.Y);
+            }
         }
     }
 }

--- a/Bonsai.Sleap.Design/LabeledImageLayer.cs
+++ b/Bonsai.Sleap.Design/LabeledImageLayer.cs
@@ -17,6 +17,7 @@ namespace Bonsai.Sleap.Design
         readonly IplImageTexture labelTexture;
         IplImage labelImage;
         Font labelFont;
+        bool hasLabels;
         bool disposed;
 
         public LabeledImageLayer()
@@ -24,6 +25,11 @@ namespace Bonsai.Sleap.Design
             GL.Enable(EnableCap.Blend);
             GL.BlendFunc(BlendingFactor.SrcAlpha, BlendingFactor.OneMinusSrcAlpha);
             labelTexture = new IplImageTexture();
+        }
+
+        public void ClearLabels()
+        {
+            hasLabels = false;
         }
 
         public void UpdateLabels(Size size, Font font, Action<Graphics, Font> draw)
@@ -48,13 +54,17 @@ namespace Bonsai.Sleap.Design
             }
 
             labelTexture.Update(labelImage);
+            hasLabels = true;
         }
 
         public void Draw()
         {
-            GL.Color4(Color4.White);
-            GL.Enable(EnableCap.Texture2D);
-            labelTexture.Draw();
+            if (hasLabels)
+            {
+                GL.Color4(Color4.White);
+                GL.Enable(EnableCap.Texture2D);
+                labelTexture.Draw();
+            }
         }
 
         protected virtual void Dispose(bool disposing)
@@ -68,6 +78,7 @@ namespace Bonsai.Sleap.Design
                     labelFont?.Dispose();
                     labelImage = null;
                     labelFont = null;
+                    hasLabels = false;
                 }
 
                 disposed = true;

--- a/Bonsai.Sleap.Design/LabeledImageLayer.cs
+++ b/Bonsai.Sleap.Design/LabeledImageLayer.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using Bonsai.Vision.Design;
+using OpenCV.Net;
+using System.Drawing.Drawing2D;
+using System.Drawing.Text;
+using System.Drawing;
+using OpenTK.Graphics;
+using OpenTK.Graphics.OpenGL;
+using Font = System.Drawing.Font;
+using Size = OpenCV.Net.Size;
+
+namespace Bonsai.Sleap.Design
+{
+    internal class LabeledImageLayer : IDisposable
+    {
+        const float LabelFontScale = 0.02f;
+        readonly IplImageTexture labelTexture;
+        IplImage labelImage;
+        Font labelFont;
+        bool disposed;
+
+        public LabeledImageLayer()
+        {
+            GL.Enable(EnableCap.Blend);
+            GL.BlendFunc(BlendingFactor.SrcAlpha, BlendingFactor.OneMinusSrcAlpha);
+            labelTexture = new IplImageTexture();
+        }
+
+        public void UpdateLabels(Size size, Font font, Action<Graphics, Font> draw)
+        {
+            if (labelImage == null || labelImage.Size != size)
+            {
+                labelImage = new IplImage(size, IplDepth.U8, 4);
+                var emSize = font.SizeInPoints * (labelImage.Height * LabelFontScale) / font.Height;
+                labelFont = new Font(font.FontFamily, emSize);
+            }
+
+            labelImage.SetZero();
+            using (var labelBitmap = new Bitmap(labelImage.Width, labelImage.Height, labelImage.WidthStep, System.Drawing.Imaging.PixelFormat.Format32bppArgb, labelImage.ImageData))
+            using (var graphics = Graphics.FromImage(labelBitmap))
+            using (var format = new StringFormat())
+            {
+                graphics.TextRenderingHint = TextRenderingHint.AntiAliasGridFit;
+                graphics.SmoothingMode = SmoothingMode.AntiAlias;
+                format.Alignment = StringAlignment.Center;
+                format.LineAlignment = StringAlignment.Center;
+                draw(graphics, labelFont);
+            }
+
+            labelTexture.Update(labelImage);
+        }
+
+        public void Draw()
+        {
+            GL.Color4(Color4.White);
+            GL.Enable(EnableCap.Texture2D);
+            labelTexture.Draw();
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposed)
+            {
+                if (disposing)
+                {
+                    labelTexture.Dispose();
+                    labelImage?.Dispose();
+                    labelFont?.Dispose();
+                    labelImage = null;
+                    labelFont = null;
+                }
+
+                disposed = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/Bonsai.Sleap.Design/LabeledPoseCollectionVisualizer.cs
+++ b/Bonsai.Sleap.Design/LabeledPoseCollectionVisualizer.cs
@@ -2,15 +2,10 @@
 using Bonsai.Vision.Design;
 using Bonsai.Sleap;
 using Bonsai.Sleap.Design;
-using OpenCV.Net;
-using OpenTK;
 using OpenTK.Graphics;
 using OpenTK.Graphics.OpenGL;
 using System;
 using System.Drawing;
-using Font = System.Drawing.Font;
-using System.Drawing.Drawing2D;
-using System.Drawing.Text;
 using System.Collections.Generic;
 
 [assembly: TypeVisualizer(typeof(LabeledPoseCollectionVisualizer), Target = typeof(LabeledPoseCollection))]
@@ -19,164 +14,96 @@ namespace Bonsai.Sleap.Design
 {
     public class LabeledPoseCollectionVisualizer : IplImageVisualizer
     {
-        IplImage labelImage;
-        LabeledPose labeledPose;
-        IplImageTexture labelTexture;
-        LabeledPoseCollection labeledPoseCollection;
-        Font labelFont;
-        float offsetBoundingBox = 0.02f;
-        Dictionary<string, int> uniqueLabels = new Dictionary<string, int>();
+        const float BoundingBoxLineWidth = 3;
+        const float BoundingBoxOffset = 0.02f;
+        readonly Dictionary<string, int> uniqueLabels = new Dictionary<string, int>();
+        LabeledPoseCollection labeledPoses;
+        LabeledImageLayer labeledImage;
 
         public override void Load(IServiceProvider provider)
         {
             base.Load(provider);
             VisualizerCanvas.Load += (sender, e) =>
             {
-                labelTexture = new IplImageTexture();
-                GL.Enable(EnableCap.Blend);
+                labeledImage = new LabeledImageLayer();
                 GL.Enable(EnableCap.PointSmooth);
-                GL.BlendFunc(BlendingFactor.SrcAlpha, BlendingFactor.OneMinusSrcAlpha);
-                GL.LineWidth(3);
+                GL.LineWidth(BoundingBoxLineWidth);
             };
         }
 
         public override void Show(object value)
         {
-            labeledPoseCollection = (LabeledPoseCollection)value;
-            if (labeledPoseCollection != null)
+            labeledPoses = (LabeledPoseCollection)value;
+            if (labeledPoses != null && labeledPoses.Count > 0)
             {
-                if (labeledPoseCollection.Count > 0)
+                base.Show(labeledPoses[0].Image);
+            }
+        }
+
+        protected override void ShowMashup(IList<object> values)
+        {
+            base.ShowMashup(values);
+            var image = VisualizerImage;
+            if (image != null && labeledPoses != null && labeledPoses.Count > 0)
+            {
+                labeledImage.UpdateLabels(image.Size, VisualizerCanvas.Font, (graphics, labelFont) =>
                 {
-                    uniqueLabels = updateUniqueLabels(labeledPoseCollection, uniqueLabels);
-                    base.Show(labeledPoseCollection[0].Image);
-                }
+                    foreach (var labeledPose in labeledPoses)
+                    {
+                        if (!uniqueLabels.TryGetValue(labeledPose.Label, out int index))
+                        {
+                            index = uniqueLabels.Count;
+                            uniqueLabels.Add(labeledPose.Label, index);
+                        }
+
+                        var position = DrawingHelper.GetBoundingBox(labeledPose, image.Size, BoundingBoxOffset)[2];
+                        graphics.DrawString(labeledPose.Label, labelFont, Brushes.White, position.X, position.Y);
+                    }
+                });
             }
-        }
-
-        public static Vector2 NormalizePoint(Point2f point, OpenCV.Net.Size imageSize)
-        {
-            return new Vector2(
-                (point.X * 2f / imageSize.Width) - 1,
-                -((point.Y * 2f / imageSize.Height) - 1));
-        }
-
-        private static Point2f[] GetBoundingBox(Pose inPose, OpenCV.Net.Size imageSize, float offsetScale)
-        {
-            float minX = float.NaN;
-            float maxX = float.NaN;
-            float minY = float.NaN;
-            float maxY = float.NaN;
-
-            float unitOffset_w = imageSize.Width * offsetScale;
-            float unitOffset_h = imageSize.Height * offsetScale;
-
-            for (int j = 0; j < inPose.Count; j++)
-            {
-                var position = inPose[j].Position;
-                if (float.IsNaN(minX)) { minX = position.X; maxX = position.X; };
-                if (float.IsNaN(minY)) { minY = position.Y; maxY = position.Y; };
-
-                minX = position.X < minX ? position.X : minX;
-                maxX = position.X > maxX ? position.X : maxX;
-                minY = position.Y < minY ? position.Y : minY;
-                maxY = position.Y > maxY ? position.Y : maxY;
-            }
-
-            minX = minX - unitOffset_w;
-            maxX = maxX + unitOffset_w;
-            minY = minY - unitOffset_h;
-            maxY = maxY + unitOffset_h;
-
-            var points = new Point2f[] {
-                new Point2f(minX, minY),
-                new Point2f(maxX, minY),
-                new Point2f(maxX, maxY),
-                new Point2f(minX, maxY)
-            };
-            return points;
         }
 
         protected override void RenderFrame()
         {
             GL.Color4(Color4.White);
             base.RenderFrame();
-            if (labeledPoseCollection != null)
+
+            if (labeledPoses != null && labeledPoses.Count > 0)
             {
+                var image = VisualizerImage;
                 GL.PointSize(5 * VisualizerCanvas.Height / 480f);
                 GL.Disable(EnableCap.Texture2D);
-                for (int j = 0; j < labeledPoseCollection.Count; j++) { 
-
-                    labeledPose = labeledPoseCollection[j];
-                    if (labeledPose != null)
+                foreach (var labeledPose in labeledPoses)
+                {
+                    // Draw all body parts
+                    GL.Begin(PrimitiveType.Points);
+                    for (int i = 0; i < labeledPose.Count; i++)
                     {
-                        // Draw all body parts
-                        GL.PointSize(5 * VisualizerCanvas.Height / 480f);
-                        GL.Disable(EnableCap.Texture2D);
-                        GL.Begin(PrimitiveType.Points);
-                        for (int i = 0; i < labeledPose.Count; i++)
-                        {
-                            var position = labeledPose[i].Position;
-                            GL.Color3(ColorPalette.GetColor(i));
-                            GL.Vertex2(NormalizePoint(position, labeledPoseCollection[0].Image.Size));
-                        }
-                        GL.End();
-
-                        var roiLimits = GetBoundingBox(labeledPose, labeledPoseCollection[0].Image.Size, offsetBoundingBox);
-                        GL.Disable(EnableCap.Texture2D);
-                        GL.Color3(ColorPalette.GetColor(uniqueLabels[labeledPoseCollection[j].Label]));
-                        GL.Begin(PrimitiveType.LineLoop);
-                        for (int i = 0; i < roiLimits.Length; i++)
-                        {
-                            GL.Vertex2(NormalizePoint(roiLimits[i], labeledPoseCollection[0].Image.Size));
-                        }
-                        GL.End();
-
-                        if (labelImage == null || labelImage.Size != labeledPoseCollection[0].Image.Size)
-                        {
-                            const float LabelFontScale = 0.03f;
-                            labelImage = new IplImage(labeledPoseCollection[0].Image.Size, IplDepth.U8, 4);
-                            var emSize = VisualizerCanvas.Font.SizeInPoints * (labelImage.Height * LabelFontScale) / VisualizerCanvas.Font.Height;
-                            labelFont = new Font(VisualizerCanvas.Font.FontFamily, emSize);
-                        }
-
-                        labelImage.SetZero();
-                        using (var labelBitmap = new Bitmap(labelImage.Width, labelImage.Height, labelImage.WidthStep, System.Drawing.Imaging.PixelFormat.Format32bppArgb, labelImage.ImageData))
-                        using (var graphics = Graphics.FromImage(labelBitmap))
-                        using (var format = new StringFormat())
-                        {
-                            graphics.TextRenderingHint = TextRenderingHint.AntiAliasGridFit;
-                            graphics.SmoothingMode = SmoothingMode.AntiAlias;
-                            format.Alignment = StringAlignment.Center;
-                            format.LineAlignment = StringAlignment.Center;
-                            var position = roiLimits[2];
-                            graphics.DrawString(labeledPose.Label, labelFont, Brushes.White, position.X, position.Y);
-                        }
-                        GL.Color4(Color4.White);
-                        GL.Enable(EnableCap.Texture2D);
-                        labelTexture.Update(labelImage);
-                        labelTexture.Draw();
+                        var position = labeledPose[i].Position;
+                        GL.Color3(ColorPalette.GetColor(i));
+                        GL.Vertex2(DrawingHelper.NormalizePoint(position, image.Size));
                     }
+                    GL.End();
+
+                    // Draw bounding box
+                    var roiLimits = DrawingHelper.GetBoundingBox(labeledPose, image.Size, BoundingBoxOffset);
+                    GL.Color3(ColorPalette.GetColor(uniqueLabels[labeledPose.Label]));
+                    GL.Begin(PrimitiveType.LineLoop);
+                    for (int i = 0; i < roiLimits.Length; i++)
+                    {
+                        GL.Vertex2(DrawingHelper.NormalizePoint(roiLimits[i], image.Size));
+                    }
+                    GL.End();
                 }
+                labeledImage.Draw();
             }
         }
         public override void Unload()
         {
             base.Unload();
             uniqueLabels.Clear();
-        }
-
-        private static Dictionary<string, int> updateUniqueLabels(LabeledPoseCollection labeledPoseCollection, Dictionary<string, int> currentLabels)
-        {
-            int nElements = currentLabels.Count;// Assume the only unique keys are present
-            foreach (var labeledPose in labeledPoseCollection)
-            {
-                if (!(currentLabels.ContainsKey(labeledPose.Label)))
-                {
-                    currentLabels[labeledPose.Label] = nElements;
-                    nElements++;
-                }
-            }
-            return currentLabels;
+            labeledImage?.Dispose();
+            labeledImage = null;
         }
     }
 }

--- a/Bonsai.Sleap.Design/LabeledPoseCollectionVisualizer.cs
+++ b/Bonsai.Sleap.Design/LabeledPoseCollectionVisualizer.cs
@@ -1,0 +1,182 @@
+﻿using Bonsai;
+using Bonsai.Vision.Design;
+using Bonsai.Sleap;
+using Bonsai.Sleap.Design;
+using OpenCV.Net;
+using OpenTK;
+using OpenTK.Graphics;
+using OpenTK.Graphics.OpenGL;
+using System;
+using System.Drawing;
+using Font = System.Drawing.Font;
+using System.Drawing.Drawing2D;
+using System.Drawing.Text;
+using System.Collections.Generic;
+
+[assembly: TypeVisualizer(typeof(LabeledPoseCollectionVisualizer), Target = typeof(LabeledPoseCollection))]
+
+namespace Bonsai.Sleap.Design
+{
+    public class LabeledPoseCollectionVisualizer : IplImageVisualizer
+    {
+        IplImage labelImage;
+        LabeledPose labeledPose;
+        IplImageTexture labelTexture;
+        LabeledPoseCollection labeledPoseCollection;
+        Font labelFont;
+        float offsetBoundingBox = 0.02f;
+        Dictionary<string, int> uniqueLabels = new Dictionary<string, int>();
+
+        public override void Load(IServiceProvider provider)
+        {
+            base.Load(provider);
+            VisualizerCanvas.Load += (sender, e) =>
+            {
+                labelTexture = new IplImageTexture();
+                GL.Enable(EnableCap.Blend);
+                GL.Enable(EnableCap.PointSmooth);
+                GL.BlendFunc(BlendingFactor.SrcAlpha, BlendingFactor.OneMinusSrcAlpha);
+                GL.LineWidth(3);
+            };
+        }
+
+        public override void Show(object value)
+        {
+            labeledPoseCollection = (LabeledPoseCollection)value;
+            if (labeledPoseCollection != null)
+            {
+                if (labeledPoseCollection.Count > 0)
+                {
+                    uniqueLabels = updateUniqueLabels(labeledPoseCollection, uniqueLabels);
+                    base.Show(labeledPoseCollection[0].Image);
+                }
+            }
+        }
+
+        public static Vector2 NormalizePoint(Point2f point, OpenCV.Net.Size imageSize)
+        {
+            return new Vector2(
+                (point.X * 2f / imageSize.Width) - 1,
+                -((point.Y * 2f / imageSize.Height) - 1));
+        }
+
+        private static Point2f[] GetBoundingBox(Pose inPose, OpenCV.Net.Size imageSize, float offsetScale)
+        {
+            float minX = float.NaN;
+            float maxX = float.NaN;
+            float minY = float.NaN;
+            float maxY = float.NaN;
+
+            float unitOffset_w = imageSize.Width * offsetScale;
+            float unitOffset_h = imageSize.Height * offsetScale;
+
+            for (int j = 0; j < inPose.Count; j++)
+            {
+                var position = inPose[j].Position;
+                if (float.IsNaN(minX)) { minX = position.X; maxX = position.X; };
+                if (float.IsNaN(minY)) { minY = position.Y; maxY = position.Y; };
+
+                minX = position.X < minX ? position.X : minX;
+                maxX = position.X > maxX ? position.X : maxX;
+                minY = position.Y < minY ? position.Y : minY;
+                maxY = position.Y > maxY ? position.Y : maxY;
+            }
+
+            minX = minX - unitOffset_w;
+            maxX = maxX + unitOffset_w;
+            minY = minY - unitOffset_h;
+            maxY = maxY + unitOffset_h;
+
+            var points = new Point2f[] {
+                new Point2f(minX, minY),
+                new Point2f(maxX, minY),
+                new Point2f(maxX, maxY),
+                new Point2f(minX, maxY)
+            };
+            return points;
+        }
+
+        protected override void RenderFrame()
+        {
+            GL.Color4(Color4.White);
+            base.RenderFrame();
+            if (labeledPoseCollection != null)
+            {
+                GL.PointSize(5 * VisualizerCanvas.Height / 480f);
+                GL.Disable(EnableCap.Texture2D);
+                for (int j = 0; j < labeledPoseCollection.Count; j++) { 
+
+                    labeledPose = labeledPoseCollection[j];
+                    if (labeledPose != null)
+                    {
+                        // Draw all body parts
+                        GL.PointSize(5 * VisualizerCanvas.Height / 480f);
+                        GL.Disable(EnableCap.Texture2D);
+                        GL.Begin(PrimitiveType.Points);
+                        for (int i = 0; i < labeledPose.Count; i++)
+                        {
+                            var position = labeledPose[i].Position;
+                            GL.Color3(ColorPalette.GetColor(i));
+                            GL.Vertex2(NormalizePoint(position, labeledPoseCollection[0].Image.Size));
+                        }
+                        GL.End();
+
+                        var roiLimits = GetBoundingBox(labeledPose, labeledPoseCollection[0].Image.Size, offsetBoundingBox);
+                        GL.Disable(EnableCap.Texture2D);
+                        GL.Color3(ColorPalette.GetColor(uniqueLabels[labeledPoseCollection[j].Label]));
+                        GL.Begin(PrimitiveType.LineLoop);
+                        for (int i = 0; i < roiLimits.Length; i++)
+                        {
+                            GL.Vertex2(NormalizePoint(roiLimits[i], labeledPoseCollection[0].Image.Size));
+                        }
+                        GL.End();
+
+                        if (labelImage == null || labelImage.Size != labeledPoseCollection[0].Image.Size)
+                        {
+                            const float LabelFontScale = 0.03f;
+                            labelImage = new IplImage(labeledPoseCollection[0].Image.Size, IplDepth.U8, 4);
+                            var emSize = VisualizerCanvas.Font.SizeInPoints * (labelImage.Height * LabelFontScale) / VisualizerCanvas.Font.Height;
+                            labelFont = new Font(VisualizerCanvas.Font.FontFamily, emSize);
+                        }
+
+                        labelImage.SetZero();
+                        using (var labelBitmap = new Bitmap(labelImage.Width, labelImage.Height, labelImage.WidthStep, System.Drawing.Imaging.PixelFormat.Format32bppArgb, labelImage.ImageData))
+                        using (var graphics = Graphics.FromImage(labelBitmap))
+                        using (var format = new StringFormat())
+                        {
+                            graphics.TextRenderingHint = TextRenderingHint.AntiAliasGridFit;
+                            graphics.SmoothingMode = SmoothingMode.AntiAlias;
+                            format.Alignment = StringAlignment.Center;
+                            format.LineAlignment = StringAlignment.Center;
+                            var position = roiLimits[2];
+                            graphics.DrawString(labeledPose.Label, labelFont, Brushes.White, position.X, position.Y);
+                        }
+                        GL.Color4(Color4.White);
+                        GL.Enable(EnableCap.Texture2D);
+                        labelTexture.Update(labelImage);
+                        labelTexture.Draw();
+                    }
+                }
+            }
+        }
+        public override void Unload()
+        {
+            base.Unload();
+            uniqueLabels.Clear();
+        }
+
+        private static Dictionary<string, int> updateUniqueLabels(LabeledPoseCollection labeledPoseCollection, Dictionary<string, int> currentLabels)
+        {
+            int nElements = currentLabels.Count;// Assume the only unique keys are present
+            foreach (var labeledPose in labeledPoseCollection)
+            {
+                if (!(currentLabels.ContainsKey(labeledPose.Label)))
+                {
+                    currentLabels[labeledPose.Label] = nElements;
+                    nElements++;
+                }
+            }
+            return currentLabels;
+        }
+    }
+}

--- a/Bonsai.Sleap.Design/LabeledPoseCollectionVisualizer.cs
+++ b/Bonsai.Sleap.Design/LabeledPoseCollectionVisualizer.cs
@@ -1,4 +1,4 @@
-using Bonsai;
+﻿using Bonsai;
 using Bonsai.Vision.Design;
 using Bonsai.Sleap;
 using Bonsai.Sleap.Design;
@@ -32,10 +32,7 @@ namespace Bonsai.Sleap.Design
         public override void Show(object value)
         {
             labeledPoses = (LabeledPoseCollection)value;
-            if (labeledPoses != null && labeledPoses.Count > 0)
-            {
-                base.Show(labeledPoses[0].Image);
-            }
+            base.Show(labeledPoses?.Image);
         }
 
         protected override void ShowMashup(IList<object> values)

--- a/Bonsai.Sleap.Design/LabeledPoseCollectionVisualizer.cs
+++ b/Bonsai.Sleap.Design/LabeledPoseCollectionVisualizer.cs
@@ -1,4 +1,4 @@
-﻿using Bonsai;
+using Bonsai;
 using Bonsai.Vision.Design;
 using Bonsai.Sleap;
 using Bonsai.Sleap.Design;
@@ -14,7 +14,6 @@ namespace Bonsai.Sleap.Design
 {
     public class LabeledPoseCollectionVisualizer : IplImageVisualizer
     {
-        const float BoundingBoxLineWidth = 3;
         const float BoundingBoxOffset = 0.02f;
         readonly Dictionary<string, int> uniqueLabels = new Dictionary<string, int>();
         LabeledPoseCollection labeledPoses;
@@ -27,7 +26,6 @@ namespace Bonsai.Sleap.Design
             {
                 labeledImage = new LabeledImageLayer();
                 GL.Enable(EnableCap.PointSmooth);
-                GL.LineWidth(BoundingBoxLineWidth);
             };
         }
 
@@ -44,7 +42,7 @@ namespace Bonsai.Sleap.Design
         {
             base.ShowMashup(values);
             var image = VisualizerImage;
-            if (image != null && labeledPoses != null && labeledPoses.Count > 0)
+            if (image != null && labeledPoses != null)
             {
                 labeledImage.UpdateLabels(image.Size, VisualizerCanvas.Font, (graphics, labelFont) =>
                 {
@@ -68,32 +66,13 @@ namespace Bonsai.Sleap.Design
             GL.Color4(Color4.White);
             base.RenderFrame();
 
-            if (labeledPoses != null && labeledPoses.Count > 0)
+            if (labeledPoses != null)
             {
-                var image = VisualizerImage;
-                GL.PointSize(5 * VisualizerCanvas.Height / 480f);
-                GL.Disable(EnableCap.Texture2D);
+                DrawingHelper.SetDrawState(VisualizerCanvas);
                 foreach (var labeledPose in labeledPoses)
                 {
-                    // Draw all body parts
-                    GL.Begin(PrimitiveType.Points);
-                    for (int i = 0; i < labeledPose.Count; i++)
-                    {
-                        var position = labeledPose[i].Position;
-                        GL.Color3(ColorPalette.GetColor(i));
-                        GL.Vertex2(DrawingHelper.NormalizePoint(position, image.Size));
-                    }
-                    GL.End();
-
-                    // Draw bounding box
-                    var roiLimits = DrawingHelper.GetBoundingBox(labeledPose, image.Size, BoundingBoxOffset);
-                    GL.Color3(ColorPalette.GetColor(uniqueLabels[labeledPose.Label]));
-                    GL.Begin(PrimitiveType.LineLoop);
-                    for (int i = 0; i < roiLimits.Length; i++)
-                    {
-                        GL.Vertex2(DrawingHelper.NormalizePoint(roiLimits[i], image.Size));
-                    }
-                    GL.End();
+                    DrawingHelper.DrawPose(labeledPose);
+                    DrawingHelper.DrawBoundingBox(labeledPose, uniqueLabels[labeledPose.Label]);
                 }
                 labeledImage.Draw();
             }

--- a/Bonsai.Sleap.Design/LabeledPoseVisualizer.cs
+++ b/Bonsai.Sleap.Design/LabeledPoseVisualizer.cs
@@ -1,4 +1,4 @@
-using Bonsai;
+﻿using Bonsai;
 using Bonsai.Vision.Design;
 using Bonsai.Sleap;
 using Bonsai.Sleap.Design;
@@ -51,10 +51,7 @@ namespace Bonsai.Sleap.Design
         public override void Show(object value)
         {
             labeledPose = (LabeledPose)value;
-            if (labeledPose != null)
-            {
-                base.Show(labeledPose.Image);
-            }
+            base.Show(labeledPose?.Image);
         }
 
         protected override void ShowMashup(IList<object> values)

--- a/Bonsai.Sleap.Design/LabeledPoseVisualizer.cs
+++ b/Bonsai.Sleap.Design/LabeledPoseVisualizer.cs
@@ -59,19 +59,23 @@ namespace Bonsai.Sleap.Design
             base.ShowMashup(values);
             if (labeledPose != null)
             {
-                labeledImage.UpdateLabels(labeledPose.Image.Size, VisualizerCanvas.Font, (graphics, labelFont) =>
+                if (DrawLabels || DrawIdentity)
                 {
-                    if (DrawLabels)
+                    labeledImage.UpdateLabels(labeledPose.Image.Size, VisualizerCanvas.Font, (graphics, labelFont) =>
                     {
-                        DrawingHelper.DrawLabels(graphics, labelFont, labeledPose);
-                    }
+                        if (DrawLabels)
+                        {
+                            DrawingHelper.DrawLabels(graphics, labelFont, labeledPose);
+                        }
 
-                    if (DrawIdentity && labeledPose.Count > 0)
-                    {
-                        var position = labeledPose[0].Position;
-                        graphics.DrawString(labeledPose.Label, labelFont, Brushes.White, position.X, position.Y);
-                    }
-                });
+                        if (DrawIdentity && labeledPose.Count > 0)
+                        {
+                            var position = labeledPose[0].Position;
+                            graphics.DrawString(labeledPose.Label, labelFont, Brushes.White, position.X, position.Y);
+                        }
+                    });
+                }
+                else labeledImage.ClearLabels();
             }
         }
 

--- a/Bonsai.Sleap.Design/LabeledPoseVisualizer.cs
+++ b/Bonsai.Sleap.Design/LabeledPoseVisualizer.cs
@@ -1,4 +1,4 @@
-﻿using Bonsai;
+using Bonsai;
 using Bonsai.Vision.Design;
 using Bonsai.Sleap;
 using Bonsai.Sleap.Design;
@@ -91,18 +91,8 @@ namespace Bonsai.Sleap.Design
 
             if (labeledPose != null)
             {
-                var pose = labeledPose;
-                GL.PointSize(5 * VisualizerCanvas.Height / 480f);
-                GL.Disable(EnableCap.Texture2D);
-                GL.Begin(PrimitiveType.Points);
-                for (int i = 0; i < pose.Count; i++)
-                {
-                    var bodyPart = pose[i];
-                    var position = bodyPart.Position;
-                    GL.Color3(ColorPalette.GetColor(i));
-                    GL.Vertex2(DrawingHelper.NormalizePoint(position, pose.Image.Size));
-                }
-                GL.End();
+                DrawingHelper.SetDrawState(VisualizerCanvas);
+                DrawingHelper.DrawPose(labeledPose);
                 labeledImage.Draw();
             }
         }

--- a/Bonsai.Sleap.Design/LabeledPoseVisualizer.cs
+++ b/Bonsai.Sleap.Design/LabeledPoseVisualizer.cs
@@ -64,20 +64,14 @@ namespace Bonsai.Sleap.Design
             {
                 labeledImage.UpdateLabels(labeledPose.Image.Size, VisualizerCanvas.Font, (graphics, labelFont) =>
                 {
-                    var pose = labeledPose;
                     if (DrawLabels)
                     {
-                        for (int i = 0; i < pose.Count; i++)
-                        {
-                            var bodyPart = pose[i];
-                            var position = bodyPart.Position;
-                            graphics.DrawString(bodyPart.Name, labelFont, Brushes.White, position.X, position.Y);
-                        }
+                        DrawingHelper.DrawLabels(graphics, labelFont, labeledPose);
                     }
 
-                    if (DrawIdentity && pose.Count > 0)
+                    if (DrawIdentity && labeledPose.Count > 0)
                     {
-                        var position = pose[0].Position;
+                        var position = labeledPose[0].Position;
                         graphics.DrawString(labeledPose.Label, labelFont, Brushes.White, position.X, position.Y);
                     }
                 });

--- a/Bonsai.Sleap.Design/PoseCollectionVisualizer.cs
+++ b/Bonsai.Sleap.Design/PoseCollectionVisualizer.cs
@@ -1,0 +1,89 @@
+﻿using Bonsai;
+using Bonsai.Vision.Design;
+using Bonsai.Sleap;
+using Bonsai.Sleap.Design;
+using OpenTK.Graphics;
+using OpenTK.Graphics.OpenGL;
+using System;
+using System.Collections.Generic;
+using System.Windows.Forms;
+
+[assembly: TypeVisualizer(typeof(PoseCollectionVisualizer), Target = typeof(PoseCollection))]
+
+namespace Bonsai.Sleap.Design
+{
+    public class PoseCollectionVisualizer : IplImageVisualizer
+    {
+        PoseCollection poses;
+        LabeledImageLayer labeledImage;
+        ToolStripButton drawLabelsButton;
+
+        public bool DrawLabels { get; set; }
+
+        public override void Load(IServiceProvider provider)
+        {
+            base.Load(provider);
+            drawLabelsButton = new ToolStripButton("Draw Labels");
+            drawLabelsButton.CheckState = CheckState.Checked;
+            drawLabelsButton.Checked = DrawLabels;
+            drawLabelsButton.CheckOnClick = true;
+            drawLabelsButton.CheckedChanged += (sender, e) => DrawLabels = drawLabelsButton.Checked;
+            StatusStrip.Items.Add(drawLabelsButton);
+
+            VisualizerCanvas.Load += (sender, e) =>
+            {
+                labeledImage = new LabeledImageLayer();
+                GL.Enable(EnableCap.PointSmooth);
+            };
+        }
+
+        public override void Show(object value)
+        {
+            poses = (PoseCollection)value;
+            base.Show(poses?.Image);
+        }
+
+        protected override void ShowMashup(IList<object> values)
+        {
+            base.ShowMashup(values);
+            var image = VisualizerImage;
+            if (image != null && poses != null)
+            {
+                if (DrawLabels)
+                {
+                    labeledImage.UpdateLabels(image.Size, VisualizerCanvas.Font, (graphics, labelFont) =>
+                    {
+                        foreach (var pose in poses)
+                        {
+                            DrawingHelper.DrawLabels(graphics, labelFont, pose);
+                        }
+                    });
+                }
+                else labeledImage.ClearLabels();
+            }
+        }
+
+        protected override void RenderFrame()
+        {
+            GL.Color4(Color4.White);
+            base.RenderFrame();
+
+            if (poses != null)
+            {
+                DrawingHelper.SetDrawState(VisualizerCanvas);
+                foreach (var pose in poses)
+                {
+                    DrawingHelper.DrawPose(pose);
+                    DrawingHelper.DrawBoundingBox(pose, 0);
+                }
+                labeledImage.Draw();
+            }
+        }
+        public override void Unload()
+        {
+            base.Unload();
+            labeledImage?.Dispose();
+            labeledImage = null;
+        }
+    }
+}

--- a/Bonsai.Sleap.Design/PoseVisualizer.cs
+++ b/Bonsai.Sleap.Design/PoseVisualizer.cs
@@ -48,13 +48,14 @@ namespace Bonsai.Sleap.Design
             base.ShowMashup(values);
             if (pose != null)
             {
-                labeledImage.UpdateLabels(pose.Image.Size, VisualizerCanvas.Font, (graphics, labelFont) =>
+                if (DrawLabels)
                 {
-                    if (DrawLabels)
+                    labeledImage.UpdateLabels(pose.Image.Size, VisualizerCanvas.Font, (graphics, labelFont) =>
                     {
                         DrawingHelper.DrawLabels(graphics, labelFont, pose);
-                    }
-                });
+                    });
+                }
+                else labeledImage.ClearLabels();
             }
         }
 

--- a/Bonsai.Sleap.Design/PoseVisualizer.cs
+++ b/Bonsai.Sleap.Design/PoseVisualizer.cs
@@ -5,7 +5,6 @@ using Bonsai.Sleap.Design;
 using OpenTK.Graphics;
 using OpenTK.Graphics.OpenGL;
 using System;
-using System.Drawing;
 using System.Windows.Forms;
 using System.Collections.Generic;
 
@@ -53,12 +52,7 @@ namespace Bonsai.Sleap.Design
                 {
                     if (DrawLabels)
                     {
-                        for (int i = 0; i < pose.Count; i++)
-                        {
-                            var bodyPart = pose[i];
-                            var position = bodyPart.Position;
-                            graphics.DrawString(bodyPart.Name, labelFont, Brushes.White, position.X, position.Y);
-                        }
+                        DrawingHelper.DrawLabels(graphics, labelFont, pose);
                     }
                 });
             }

--- a/Bonsai.Sleap.Design/PoseVisualizer.cs
+++ b/Bonsai.Sleap.Design/PoseVisualizer.cs
@@ -1,4 +1,4 @@
-using Bonsai;
+﻿using Bonsai;
 using Bonsai.Vision.Design;
 using Bonsai.Sleap;
 using Bonsai.Sleap.Design;
@@ -71,17 +71,8 @@ namespace Bonsai.Sleap.Design
 
             if (pose != null)
             {
-                GL.PointSize(5 * VisualizerCanvas.Height / 480f);
-                GL.Disable(EnableCap.Texture2D);
-                GL.Begin(PrimitiveType.Points);
-                for (int i = 0; i < pose.Count; i++)
-                {
-                    var bodyPart = pose[i];
-                    var position = bodyPart.Position;
-                    GL.Color3(ColorPalette.GetColor(i));
-                    GL.Vertex2(DrawingHelper.NormalizePoint(position, pose.Image.Size));
-                }
-                GL.End();
+                DrawingHelper.SetDrawState(VisualizerCanvas);
+                DrawingHelper.DrawPose(pose);
                 labeledImage.Draw();
             }
         }

--- a/Bonsai.Sleap.Design/PoseVisualizer.cs
+++ b/Bonsai.Sleap.Design/PoseVisualizer.cs
@@ -1,17 +1,13 @@
-﻿using Bonsai;
+using Bonsai;
 using Bonsai.Vision.Design;
 using Bonsai.Sleap;
 using Bonsai.Sleap.Design;
-using OpenCV.Net;
-using OpenTK;
 using OpenTK.Graphics;
 using OpenTK.Graphics.OpenGL;
 using System;
 using System.Drawing;
-using System.Drawing.Drawing2D;
-using System.Drawing.Text;
 using System.Windows.Forms;
-using Font = System.Drawing.Font;
+using System.Collections.Generic;
 
 [assembly: TypeVisualizer(typeof(PoseVisualizer), Target = typeof(Pose))]
 
@@ -20,12 +16,10 @@ namespace Bonsai.Sleap.Design
     public class PoseVisualizer : IplImageVisualizer
     {
         Pose pose;
-        IplImage labelImage;
-        IplImageTexture labelTexture;
+        LabeledImageLayer labeledImage;
         ToolStripButton drawLabelsButton;
-        Font labelFont;
 
-        public bool DrawLabels { get; set; } = false;
+        public bool DrawLabels { get; set; }
 
         public override void Load(IServiceProvider provider)
         {
@@ -39,32 +33,39 @@ namespace Bonsai.Sleap.Design
 
             VisualizerCanvas.Load += (sender, e) =>
             {
-                labelTexture = new IplImageTexture();
-                GL.Enable(EnableCap.Blend);
+                labeledImage = new LabeledImageLayer();
                 GL.Enable(EnableCap.PointSmooth);
-                GL.BlendFunc(BlendingFactor.SrcAlpha, BlendingFactor.OneMinusSrcAlpha);
             };
         }
 
         public override void Show(object value)
         {
             pose = (Pose)value;
-            if (pose != null)
-            {
-                base.Show(pose.Image);
-            }
+            base.Show(pose?.Image);
         }
 
-        public static Vector2 NormalizePoint(Point2f point, OpenCV.Net.Size imageSize)
+        protected override void ShowMashup(IList<object> values)
         {
-            return new Vector2(
-                (point.X * 2f / imageSize.Width) - 1,
-                -((point.Y * 2f / imageSize.Height) - 1));
+            base.ShowMashup(values);
+            if (pose != null)
+            {
+                labeledImage.UpdateLabels(pose.Image.Size, VisualizerCanvas.Font, (graphics, labelFont) =>
+                {
+                    if (DrawLabels)
+                    {
+                        for (int i = 0; i < pose.Count; i++)
+                        {
+                            var bodyPart = pose[i];
+                            var position = bodyPart.Position;
+                            graphics.DrawString(bodyPart.Name, labelFont, Brushes.White, position.X, position.Y);
+                        }
+                    }
+                });
+            }
         }
 
         protected override void RenderFrame()
         {
-            var drawLabels = DrawLabels;
             GL.Color4(Color4.White);
             base.RenderFrame();
 
@@ -75,47 +76,21 @@ namespace Bonsai.Sleap.Design
                 GL.Begin(PrimitiveType.Points);
                 for (int i = 0; i < pose.Count; i++)
                 {
-
                     var bodyPart = pose[i];
                     var position = bodyPart.Position;
                     GL.Color3(ColorPalette.GetColor(i));
-                    GL.Vertex2(NormalizePoint(position, pose.Image.Size));
+                    GL.Vertex2(DrawingHelper.NormalizePoint(position, pose.Image.Size));
                 }
                 GL.End();
-
-                if (drawLabels)
-                {
-                    if (labelImage == null || labelImage.Size != pose.Image.Size)
-                    {
-                        const float LabelFontScale = 0.02f;
-                        labelImage = new IplImage(pose.Image.Size, IplDepth.U8, 4);
-                        var emSize = VisualizerCanvas.Font.SizeInPoints * (labelImage.Height * LabelFontScale) / VisualizerCanvas.Font.Height;
-                        labelFont = new Font(VisualizerCanvas.Font.FontFamily, emSize);
-                    }
-
-                    labelImage.SetZero();
-                    using (var labelBitmap = new Bitmap(labelImage.Width, labelImage.Height, labelImage.WidthStep, System.Drawing.Imaging.PixelFormat.Format32bppArgb, labelImage.ImageData))
-                    using (var graphics = Graphics.FromImage(labelBitmap))
-                    using (var format = new StringFormat())
-                    {
-                        graphics.TextRenderingHint = TextRenderingHint.AntiAliasGridFit;
-                        graphics.SmoothingMode = SmoothingMode.AntiAlias;
-                        format.Alignment = StringAlignment.Center;
-                        format.LineAlignment = StringAlignment.Center;
-                        for (int i = 0; i < pose.Count; i++)
-                        {
-                            var bodyPart = pose[i];
-                            var position = bodyPart.Position;
-                            graphics.DrawString(bodyPart.Name, labelFont, Brushes.White, position.X, position.Y);
-                        }
-                    }
-
-                    GL.Color4(Color4.White);
-                    GL.Enable(EnableCap.Texture2D);
-                    labelTexture.Update(labelImage);
-                    labelTexture.Draw();
-                }
+                labeledImage.Draw();
             }
+        }
+
+        public override void Unload()
+        {
+            base.Unload();
+            labeledImage?.Dispose();
+            labeledImage = null;
         }
     }
 }

--- a/Bonsai.Sleap.Examples/CentroidModel.bonsai
+++ b/Bonsai.Sleap.Examples/CentroidModel.bonsai
@@ -22,7 +22,7 @@
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="sleap:PredictCentroids">
           <sleap:ModelFileName>models\centroid_only_model\frozen_graph.pb</sleap:ModelFileName>
-          <sleap:TrainingConfig>models\centroid.fast.210504_182918.centroid.n=1800\training_config.json</sleap:TrainingConfig>
+          <sleap:TrainingConfig>models\centroid_only_model\training_config.json</sleap:TrainingConfig>
           <sleap:CentroidMinConfidence xsi:nil="true" />
           <sleap:ScaleFactor xsi:nil="true" />
           <sleap:ColorConversion xsi:nil="true" />

--- a/Bonsai.Sleap.Examples/CentroidModel.bonsai
+++ b/Bonsai.Sleap.Examples/CentroidModel.bonsai
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<WorkflowBuilder Version="2.7.0-rc1"
+<WorkflowBuilder Version="2.7.0-rc4"
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xmlns:cv="clr-namespace:Bonsai.Vision;assembly=Bonsai.Vision"
                  xmlns:sleap="clr-namespace:Bonsai.Sleap;assembly=Bonsai.Sleap"
@@ -8,8 +8,8 @@
     <Nodes>
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="cv:FileCapture">
-          <cv:FileName>C:\Users\neurogears\Documents\git\bruno-f-cruz\SLEAPyBonsai\All models\bonsai_test\Original\video.mp4</cv:FileName>
-          <cv:PlaybackRate>99999</cv:PlaybackRate>
+          <cv:FileName>movies\video.mp4</cv:FileName>
+          <cv:PlaybackRate>9999</cv:PlaybackRate>
           <cv:StartPosition>0.5</cv:StartPosition>
           <cv:PositionUnits>Frames</cv:PositionUnits>
           <cv:Loop>true</cv:Loop>
@@ -21,8 +21,8 @@
       </Expression>
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="sleap:PredictCentroids">
-          <sleap:ModelFileName>C:\Users\neurogears\Documents\git\bruno-f-cruz\SLEAPyBonsai\All models\bonsai_test\bonsai_graphs\centroid_only_model\frozen_graph.pb</sleap:ModelFileName>
-          <sleap:TrainingConfig>C:\Users\neurogears\Documents\git\bruno-f-cruz\SLEAPyBonsai\PostFeedbackModels\centroid.fast.210504_182918.centroid.n=1800\training_config.json</sleap:TrainingConfig>
+          <sleap:ModelFileName>models\centroid_only_model\frozen_graph.pb</sleap:ModelFileName>
+          <sleap:TrainingConfig>models\centroid.fast.210504_182918.centroid.n=1800\training_config.json</sleap:TrainingConfig>
           <sleap:CentroidMinConfidence xsi:nil="true" />
           <sleap:ScaleFactor xsi:nil="true" />
           <sleap:ColorConversion xsi:nil="true" />

--- a/Bonsai.Sleap.Examples/FullTopDownModel.bonsai
+++ b/Bonsai.Sleap.Examples/FullTopDownModel.bonsai
@@ -30,10 +30,10 @@
           <sleap:ColorConversion xsi:nil="true" />
         </Combinator>
       </Expression>
-      <Expression xsi:type="Index">
-        <Operand xsi:type="IntProperty">
-          <Value>0</Value>
-        </Operand>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="sleap:GetMaximumConfidenceLabel">
+          <sleap:Label />
+        </Combinator>
       </Expression>
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="sleap:GetBodyPart">

--- a/Bonsai.Sleap.Examples/FullTopDownModel.bonsai
+++ b/Bonsai.Sleap.Examples/FullTopDownModel.bonsai
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<WorkflowBuilder Version="2.7.0-rc1"
+<WorkflowBuilder Version="2.7.0-rc4"
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xmlns:cv="clr-namespace:Bonsai.Vision;assembly=Bonsai.Vision"
                  xmlns:sleap="clr-namespace:Bonsai.Sleap;assembly=Bonsai.Sleap"
@@ -8,8 +8,8 @@
     <Nodes>
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="cv:FileCapture">
-          <cv:FileName>C:\Users\neurogears\Documents\git\bruno-f-cruz\SLEAPyBonsai\All models\bonsai_test\Original\video.mp4</cv:FileName>
-          <cv:PlaybackRate>10</cv:PlaybackRate>
+          <cv:FileName>movies\video.mp4</cv:FileName>
+          <cv:PlaybackRate>9999</cv:PlaybackRate>
           <cv:StartPosition>0.5</cv:StartPosition>
           <cv:PositionUnits>Frames</cv:PositionUnits>
           <cv:Loop>true</cv:Loop>
@@ -20,10 +20,11 @@
         <Combinator xsi:type="cv:Grayscale" />
       </Expression>
       <Expression xsi:type="Combinator">
-        <Combinator xsi:type="sleap:PredictPoses">
-          <sleap:ModelFileName>C:\Users\neurogears\Documents\git\bruno-f-cruz\SLEAPyBonsai\All models\bonsai_test\bonsai_graphs\top_down_model\frozen_graph.pb</sleap:ModelFileName>
-          <sleap:TrainingConfig>C:\Users\neurogears\Documents\git\bruno-f-cruz\SLEAPyBonsai\All models\bonsai_test\Original\centered_instance_model\training_config.json</sleap:TrainingConfig>
+        <Combinator xsi:type="sleap:PredictLabeledPoses">
+          <sleap:ModelFileName>models\top_down_id_model\frozen_graph.pb</sleap:ModelFileName>
+          <sleap:TrainingConfig>models\top_down_id_model\training_config.json</sleap:TrainingConfig>
           <sleap:CentroidMinConfidence xsi:nil="true" />
+          <sleap:IdentityMinConfidence xsi:nil="true" />
           <sleap:PartMinConfidence xsi:nil="true" />
           <sleap:ScaleFactor xsi:nil="true" />
           <sleap:ColorConversion xsi:nil="true" />
@@ -43,6 +44,9 @@
         <Selector>Position</Selector>
       </Expression>
       <Expression xsi:type="MemberSelector">
+        <Selector>Label</Selector>
+      </Expression>
+      <Expression xsi:type="MemberSelector">
         <Selector>Centroid</Selector>
       </Expression>
     </Nodes>
@@ -52,6 +56,7 @@
       <Edge From="2" To="3" Label="Source1" />
       <Edge From="3" To="4" Label="Source1" />
       <Edge From="3" To="6" Label="Source1" />
+      <Edge From="3" To="7" Label="Source1" />
       <Edge From="4" To="5" Label="Source1" />
     </Edges>
   </Workflow>

--- a/Bonsai.Sleap.Examples/SingleInstanceModel.bonsai
+++ b/Bonsai.Sleap.Examples/SingleInstanceModel.bonsai
@@ -97,7 +97,7 @@
         <Selector>Position</Selector>
       </Expression>
       <Expression xsi:type="MemberSelector">
-        <Selector>Count</Selector>
+        <Selector>Centroid</Selector>
       </Expression>
     </Nodes>
     <Edges>

--- a/Bonsai.Sleap.Examples/SingleInstanceModel.bonsai
+++ b/Bonsai.Sleap.Examples/SingleInstanceModel.bonsai
@@ -9,8 +9,8 @@
     <Nodes>
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="cv:FileCapture">
-          <cv:FileName>C:\Users\neurogears\Documents\git\bruno-f-cruz\SLEAPyBonsai\All models\bonsai_test\BermanFlies\072212_163153@10000-13200@0-3199.mp4</cv:FileName>
-          <cv:PlaybackRate>10</cv:PlaybackRate>
+          <cv:FileName>movies\video.mp4</cv:FileName>
+          <cv:PlaybackRate>9999</cv:PlaybackRate>
           <cv:StartPosition>0.5</cv:StartPosition>
           <cv:PositionUnits>Frames</cv:PositionUnits>
           <cv:Loop>true</cv:Loop>
@@ -89,8 +89,8 @@
       </Expression>
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="sleap:PredictSinglePose">
-          <sleap:ModelFileName>C:\Users\neurogears\Documents\git\bruno-f-cruz\SLEAPyBonsai\All models\bonsai_test\bonsai_graphs\single_instance_model\frozen_graph.pb</sleap:ModelFileName>
-          <sleap:TrainingConfig>C:\Users\neurogears\Documents\git\bruno-f-cruz\SLEAPyBonsai\All models\bonsai_test\BermanFlies\single_instance_model_fast_unet\training_config.json</sleap:TrainingConfig>
+          <sleap:ModelFileName>models\single_instance_model\frozen_graph.pb</sleap:ModelFileName>
+          <sleap:TrainingConfig>models\single_instance_model_fast_unet\training_config.json</sleap:TrainingConfig>
           <sleap:PartMinConfidence xsi:nil="true" />
           <sleap:ScaleFactor xsi:nil="true" />
           <sleap:ColorConversion xsi:nil="true" />

--- a/Bonsai.Sleap.Examples/SingleInstanceModel.bonsai
+++ b/Bonsai.Sleap.Examples/SingleInstanceModel.bonsai
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<WorkflowBuilder Version="2.7.0-rc1"
+<WorkflowBuilder Version="2.7.0-rc4"
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xmlns:cv="clr-namespace:Bonsai.Vision;assembly=Bonsai.Vision"
                  xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
@@ -58,19 +58,6 @@
         <Combinator xsi:type="cv:BinaryRegionAnalysis" />
       </Expression>
       <Expression xsi:type="Combinator">
-        <Combinator xsi:type="cv:TakeBinaryRegions">
-          <cv:Count>1</cv:Count>
-        </Combinator>
-      </Expression>
-      <Expression xsi:type="Index">
-        <Operand xsi:type="IntProperty">
-          <Value>0</Value>
-        </Operand>
-      </Expression>
-      <Expression xsi:type="MemberSelector">
-        <Selector>Centroid</Selector>
-      </Expression>
-      <Expression xsi:type="Combinator">
         <Combinator xsi:type="rx:Zip" />
       </Expression>
       <Expression xsi:type="Combinator">
@@ -90,11 +77,16 @@
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="sleap:PredictSinglePose">
           <sleap:ModelFileName>models\single_instance_model\frozen_graph.pb</sleap:ModelFileName>
-          <sleap:TrainingConfig>models\single_instance_model_fast_unet\training_config.json</sleap:TrainingConfig>
+          <sleap:TrainingConfig>models\single_instance_model\training_config.json</sleap:TrainingConfig>
           <sleap:PartMinConfidence xsi:nil="true" />
           <sleap:ScaleFactor xsi:nil="true" />
           <sleap:ColorConversion xsi:nil="true" />
         </Combinator>
+      </Expression>
+      <Expression xsi:type="Index">
+        <Operand xsi:type="IntProperty">
+          <Value>0</Value>
+        </Operand>
       </Expression>
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="sleap:GetBodyPart">
@@ -111,19 +103,17 @@
     <Edges>
       <Edge From="0" To="1" Label="Source1" />
       <Edge From="1" To="2" Label="Source1" />
-      <Edge From="1" To="9" Label="Source1" />
+      <Edge From="1" To="6" Label="Source1" />
       <Edge From="2" To="3" Label="Source1" />
       <Edge From="3" To="4" Label="Source1" />
       <Edge From="4" To="5" Label="Source1" />
-      <Edge From="5" To="6" Label="Source1" />
+      <Edge From="5" To="6" Label="Source2" />
       <Edge From="6" To="7" Label="Source1" />
       <Edge From="7" To="8" Label="Source1" />
-      <Edge From="8" To="9" Label="Source2" />
+      <Edge From="8" To="9" Label="Source1" />
       <Edge From="9" To="10" Label="Source1" />
+      <Edge From="9" To="12" Label="Source1" />
       <Edge From="10" To="11" Label="Source1" />
-      <Edge From="11" To="12" Label="Source1" />
-      <Edge From="11" To="14" Label="Source1" />
-      <Edge From="12" To="13" Label="Source1" />
     </Edges>
   </Workflow>
 </WorkflowBuilder>

--- a/Bonsai.Sleap.Examples/TopDownNoIDModel.bonsai
+++ b/Bonsai.Sleap.Examples/TopDownNoIDModel.bonsai
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<WorkflowBuilder Version="2.7.0-rc1"
+<WorkflowBuilder Version="2.7.0-rc4"
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xmlns:cv="clr-namespace:Bonsai.Vision;assembly=Bonsai.Vision"
                  xmlns:sleap="clr-namespace:Bonsai.Sleap;assembly=Bonsai.Sleap"
@@ -8,7 +8,7 @@
     <Nodes>
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="cv:FileCapture">
-          <cv:FileName>C:\Users\neurogears\Documents\git\bruno-f-cruz\SLEAPyBonsai\All models\bonsai_test\Original\video.mp4</cv:FileName>
+          <cv:FileName>movies\video.mp4</cv:FileName>
           <cv:PlaybackRate>9999</cv:PlaybackRate>
           <cv:StartPosition>0.5</cv:StartPosition>
           <cv:PositionUnits>Frames</cv:PositionUnits>
@@ -20,11 +20,10 @@
         <Combinator xsi:type="cv:Grayscale" />
       </Expression>
       <Expression xsi:type="Combinator">
-        <Combinator xsi:type="sleap:PredictLabeledPoses">
-          <sleap:ModelFileName>C:\Users\neurogears\Documents\git\bruno-f-cruz\SLEAPyBonsai\All models\bonsai_test\bonsai_graphs\top_down_id_model\frozen_graph.pb</sleap:ModelFileName>
-          <sleap:TrainingConfig>C:\Users\neurogears\Documents\git\bruno-f-cruz\SLEAPyBonsai\All models\bonsai_test\Wt_gold.13pt\top_down_id_model\training_config.json</sleap:TrainingConfig>
+        <Combinator xsi:type="sleap:PredictPoses">
+          <sleap:ModelFileName>models\top_down_model\frozen_graph.pb</sleap:ModelFileName>
+          <sleap:TrainingConfig>models\centered_instance_model\training_config.json</sleap:TrainingConfig>
           <sleap:CentroidMinConfidence xsi:nil="true" />
-          <sleap:IdentityMinConfidence xsi:nil="true" />
           <sleap:PartMinConfidence xsi:nil="true" />
           <sleap:ScaleFactor xsi:nil="true" />
           <sleap:ColorConversion xsi:nil="true" />
@@ -44,9 +43,6 @@
         <Selector>Position</Selector>
       </Expression>
       <Expression xsi:type="MemberSelector">
-        <Selector>Label</Selector>
-      </Expression>
-      <Expression xsi:type="MemberSelector">
         <Selector>Centroid</Selector>
       </Expression>
     </Nodes>
@@ -56,7 +52,6 @@
       <Edge From="2" To="3" Label="Source1" />
       <Edge From="3" To="4" Label="Source1" />
       <Edge From="3" To="6" Label="Source1" />
-      <Edge From="3" To="7" Label="Source1" />
       <Edge From="4" To="5" Label="Source1" />
     </Edges>
   </Workflow>

--- a/Bonsai.Sleap/Centroid.cs
+++ b/Bonsai.Sleap/Centroid.cs
@@ -2,7 +2,7 @@
 
 namespace Bonsai.Sleap
 {
-    public class Centroid
+    public class Centroid : BodyPart
     {
         public Centroid(IplImage image)
         {
@@ -10,16 +10,5 @@ namespace Bonsai.Sleap
         }
 
         public IplImage Image { get; }
-
-        public string Name { get; set; }
-
-        public Point2f Position { get; set; }
-
-        public float Confidence { get; set; }
-
     }
-
 }
-
-
-

--- a/Bonsai.Sleap/Centroid.cs
+++ b/Bonsai.Sleap/Centroid.cs
@@ -9,7 +9,7 @@ namespace Bonsai.Sleap
             Image = image;
         }
 
-        public IplImage Image { get; private set; }
+        public IplImage Image { get; }
 
         public string Name { get; set; }
 

--- a/Bonsai.Sleap/CentroidCollection.cs
+++ b/Bonsai.Sleap/CentroidCollection.cs
@@ -1,17 +1,15 @@
-﻿using System.Collections.Generic;
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
+using OpenCV.Net;
 
 namespace Bonsai.Sleap
 {
     public class CentroidCollection : Collection<Centroid>
     {
-        public CentroidCollection()
+        public CentroidCollection(IplImage image)
         {
+            Image = image;
         }
 
-        public CentroidCollection(IList<Centroid> list)
-            : base(list)
-        {
-        }
+        public IplImage Image { get; }
     }
 }

--- a/Bonsai.Sleap/GetLabeledPose.cs
+++ b/Bonsai.Sleap/GetLabeledPose.cs
@@ -18,7 +18,7 @@ namespace Bonsai.Sleap
             {
                 var label = Label;
                 return !string.IsNullOrEmpty(label)
-                    ? new LabeledPoseCollection(poses.Where(x => x.Label == label).ToList())
+                    ? new LabeledPoseCollection(poses.Where(x => x.Label == label).ToList(), poses.Image)
                     : poses;
             });
         }

--- a/Bonsai.Sleap/GetMaximumConfidenceLabel.cs
+++ b/Bonsai.Sleap/GetMaximumConfidenceLabel.cs
@@ -2,7 +2,6 @@
 using System.ComponentModel;
 using System.Linq;
 using System.Reactive.Linq;
-using System.Collections.Generic;
 using OpenCV.Net;
 
 namespace Bonsai.Sleap
@@ -19,53 +18,35 @@ namespace Bonsai.Sleap
             return source.Select(poses =>
             {
                 var label = Label;
-                if (string.IsNullOrEmpty(label))
+                int maxIndex = -1;
+                for (int i = 0; i < poses.Count; i++)
                 {
-                    var topConfIdx = ArgMax(poses.Select(x => x.Confidence).ToArray(), Comparer<float>.Default, out float maxScore);
-                    return topConfIdx >= 0 ? poses[topConfIdx] : DefaultPose(poses.Image, string.Empty);
-                }
-                else // do a search for the label
-                {
-                    var filtposes = poses.Where(x => x.Label == label).ToList();
-                    if (!filtposes.Any()){return DefaultPose(poses.Image, label);}
-                    else
+                    var pose = poses[i];
+                    if (!string.IsNullOrEmpty(label) && pose.Label != label)
                     {
-                        var topConfIdx = ArgMax(filtposes.Select(x => x.Confidence).ToArray(), Comparer<float>.Default, out float _);
-                        return topConfIdx >= 0 ? filtposes[topConfIdx] : DefaultPose(poses.Image, label);
+                        continue;
+                    }
+
+                    if (maxIndex < 0 || pose.Confidence > poses[maxIndex].Confidence)
+                    {
+                        maxIndex = i;
                     }
                 }
+
+                return maxIndex < 0 ? DefaultPose(poses.Image, label) : poses[maxIndex];
             });
         }
 
-        static int ArgMax<TElement>(TElement[] array, IComparer<TElement> comparer, out TElement maxValue)
-        {
-            if (array == null) throw new ArgumentNullException(nameof(array));
-            if (comparer == null) throw new ArgumentNullException(nameof(comparer));
-
-            int maxIndex = -1;
-            maxValue = default;
-            for (int i = 0; i < array.Count(); i++)
-            {
-                if (i == 0 || comparer.Compare(array[i], maxValue) > 0)
-                {
-                    maxIndex = i;
-                    maxValue = array[i];
-                }
-            }
-            return maxIndex;
-        }
-
-        private static LabeledPose DefaultPose(IplImage image, String label)
+        static LabeledPose DefaultPose(IplImage image, string label)
         {
             var pose = new LabeledPose(image)
             {
-                Confidence = float.NaN,
                 Label = label,
+                Confidence = float.NaN,
                 Centroid = new Centroid(image)
                 {
                     Position = new Point2f(float.NaN, float.NaN),
-                    Confidence = float.NaN,
-                    Name = null
+                    Confidence = float.NaN
                 }
             };
             return pose;

--- a/Bonsai.Sleap/GetMaximumConfidenceLabel.cs
+++ b/Bonsai.Sleap/GetMaximumConfidenceLabel.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Collections.Generic;
+using OpenCV.Net;
+
+namespace Bonsai.Sleap
+{
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Returns the labeled pose with the highest identity confidence, using the optional class label.")]
+    public class GetMaximumConfidenceLabel : Transform<LabeledPoseCollection, LabeledPose>
+    {
+        [Description("The class label used to filter the labeled pose collection.")]
+        public string Label { get; set; }
+
+        public override IObservable<LabeledPose> Process(IObservable<LabeledPoseCollection> source)
+        {
+            return source.Select(poses =>
+            {
+                var label = Label;
+                if (string.IsNullOrEmpty(label))
+                {
+                    var topConfIdx = ArgMax(poses.Select(x => x.Confidence).ToArray(), Comparer<float>.Default, out float maxScore);
+                    return topConfIdx >= 0 ? poses[topConfIdx] : DefaultPose(poses.Image, string.Empty);
+                }
+                else // do a search for the label
+                {
+                    var filtposes = poses.Where(x => x.Label == label).ToList();
+                    if (!filtposes.Any()){return DefaultPose(poses.Image, label);}
+                    else
+                    {
+                        var topConfIdx = ArgMax(filtposes.Select(x => x.Confidence).ToArray(), Comparer<float>.Default, out float _);
+                        return topConfIdx >= 0 ? filtposes[topConfIdx] : DefaultPose(poses.Image, label);
+                    }
+                }
+            });
+        }
+
+        static int ArgMax<TElement>(TElement[] array, IComparer<TElement> comparer, out TElement maxValue)
+        {
+            if (array == null) throw new ArgumentNullException(nameof(array));
+            if (comparer == null) throw new ArgumentNullException(nameof(comparer));
+
+            int maxIndex = -1;
+            maxValue = default;
+            for (int i = 0; i < array.Count(); i++)
+            {
+                if (i == 0 || comparer.Compare(array[i], maxValue) > 0)
+                {
+                    maxIndex = i;
+                    maxValue = array[i];
+                }
+            }
+            return maxIndex;
+        }
+
+        private static LabeledPose DefaultPose(IplImage image, String label)
+        {
+            var pose = new LabeledPose(image)
+            {
+                Confidence = float.NaN,
+                Label = label,
+                Centroid = new Centroid(image)
+                {
+                    Position = new Point2f(float.NaN, float.NaN),
+                    Confidence = float.NaN,
+                    Name = null
+                }
+            };
+            return pose;
+        }
+    }
+}

--- a/Bonsai.Sleap/GetMaximumConfidenceLabel.cs
+++ b/Bonsai.Sleap/GetMaximumConfidenceLabel.cs
@@ -39,17 +39,17 @@ namespace Bonsai.Sleap
 
         static LabeledPose DefaultPose(IplImage image, string label)
         {
-            var pose = new LabeledPose(image)
+            return new LabeledPose(image)
             {
                 Label = label,
                 Confidence = float.NaN,
-                Centroid = new Centroid(image)
+                Centroid = new BodyPart
                 {
+                    Name = label,
                     Position = new Point2f(float.NaN, float.NaN),
-                    Confidence = float.NaN
+                    Confidence = 0
                 }
             };
-            return pose;
         }
     }
 }

--- a/Bonsai.Sleap/LabeledPoseCollection.cs
+++ b/Bonsai.Sleap/LabeledPoseCollection.cs
@@ -1,18 +1,23 @@
 ﻿using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using OpenCV.Net;
 
 namespace Bonsai.Sleap
 {
     public class LabeledPoseCollection : Collection<LabeledPose>
     {
-        public LabeledPoseCollection()
+        public LabeledPoseCollection(IplImage image)
         {
+            Image = image;
         }
 
-        public LabeledPoseCollection(IList<LabeledPose> list)
+        public LabeledPoseCollection(IList<LabeledPose> list, IplImage image)
             : base(list)
         {
+            Image = image;
         }
+
+        public IplImage Image { get; }
     }
 
 }

--- a/Bonsai.Sleap/Pose.cs
+++ b/Bonsai.Sleap/Pose.cs
@@ -12,7 +12,7 @@ namespace Bonsai.Sleap
 
         public IplImage Image { get; }
 
-        public Centroid Centroid { get; set; }
+        public BodyPart Centroid { get; set; }
 
         protected override string GetKeyForItem(BodyPart item)
         {
@@ -20,7 +20,7 @@ namespace Bonsai.Sleap
         }
     }
 
-    public struct BodyPart
+    public class BodyPart
     {
         public string Name;
         public Point2f Position;

--- a/Bonsai.Sleap/Pose.cs
+++ b/Bonsai.Sleap/Pose.cs
@@ -10,7 +10,7 @@ namespace Bonsai.Sleap
             Image = image;
         }
 
-        public IplImage Image { get; private set; }
+        public IplImage Image { get; }
 
         public Centroid Centroid { get; set; }
 

--- a/Bonsai.Sleap/PoseCollection.cs
+++ b/Bonsai.Sleap/PoseCollection.cs
@@ -1,17 +1,15 @@
-﻿using System.Collections.Generic;
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
+using OpenCV.Net;
 
 namespace Bonsai.Sleap
 {
     public class PoseCollection : Collection<Pose>
     {
-        public PoseCollection()
+        public PoseCollection(IplImage image)
         {
+            Image = image;
         }
-         
-        public PoseCollection(IList<Pose> list)
-            : base(list)
-        {
-        }
+
+        public IplImage Image { get; }
     }
 }

--- a/Bonsai.Sleap/PredictCentroids.cs
+++ b/Bonsai.Sleap/PredictCentroids.cs
@@ -82,8 +82,9 @@ namespace Bonsai.Sleap
                     });
                     TensorHelper.UpdateTensor(tensor, colorChannels, frames);
                     var output = runner.Run();
-
-                    if (output[0].Shape[0] == 0) return new CentroidCollection();
+                    
+                    var centroidCollection = new CentroidCollection(input[0]);
+                    if (output[0].Shape[0] == 0) return centroidCollection;
                     else
                     {
                         // Fetch the results from output
@@ -95,9 +96,7 @@ namespace Bonsai.Sleap
                         float[,] centroidArr = new float[centroidTensor.Shape[0], centroidTensor.Shape[1]];
                         centroidTensor.GetValue(centroidArr);
 
-                        var centroidPoseCollection = new CentroidCollection();
                         var confidenceThreshold = CentroidMinConfidence;
-
                         for (int i = 0; i < centroidConfArr.GetLength(0); i++)
                         {
                             //TODO not sure what to do here if multiple images are given....
@@ -115,9 +114,9 @@ namespace Bonsai.Sleap
                                     (float)(centroidArr[i, 0] * poseScale),
                                     (float)(centroidArr[i, 1] * poseScale));
                             }
-                            centroidPoseCollection.Add(centroid);
+                            centroidCollection.Add(centroid);
                         };
-                        return centroidPoseCollection;
+                        return centroidCollection;
                     }
                 });
             });

--- a/Bonsai.Sleap/PredictCentroids.cs
+++ b/Bonsai.Sleap/PredictCentroids.cs
@@ -32,7 +32,7 @@ namespace Bonsai.Sleap
         [Description("The optional color conversion used to prepare RGB video frames for inference.")]
         public ColorConversion? ColorConversion { get; set; }
 
-        public IObservable<CentroidCollection> Process(IObservable<IplImage[]> source)
+        private IObservable<CentroidCollection> Process(IObservable<IplImage[]> source)
         {
             return Observable.Defer(() =>
             {

--- a/Bonsai.Sleap/PredictLabeledPoses.cs
+++ b/Bonsai.Sleap/PredictLabeledPoses.cs
@@ -124,7 +124,7 @@ namespace Bonsai.Sleap
 
                         var partThreshold = PartMinConfidence;
                         var idThreshold = IdentityMinConfidence;
-                        var centroidTreshold = CentroidMinConfidence;
+                        var centroidThreshold = CentroidMinConfidence;
 
                         for (int iid = 0; iid < idArr.GetLength(0); iid++)
                         {
@@ -138,9 +138,10 @@ namespace Bonsai.Sleap
                             }
                             else labeledPose.Label = config.ClassNames[maxIndex];
 
-                            var centroid = new Centroid(input[0]);
+                            var centroid = new BodyPart();
+                            centroid.Name = labeledPose.Label;
                             centroid.Confidence = centroidConfArr[0];
-                            if (centroid.Confidence < centroidTreshold)
+                            if (centroid.Confidence < centroidThreshold)
                             {
                                 centroid.Position = new Point2f(float.NaN, float.NaN);
                             }
@@ -155,7 +156,7 @@ namespace Bonsai.Sleap
                             // Iterate on the body parts
                             for (int bodyPartIdx = 0; bodyPartIdx < poseArr.GetLength(1); bodyPartIdx++)
                             {
-                                BodyPart bodyPart;
+                                var bodyPart = new BodyPart();
                                 bodyPart.Name = config.PartNames[bodyPartIdx];
                                 bodyPart.Confidence = partConfArr[iid, bodyPartIdx];
                                 if (bodyPart.Confidence < partThreshold)

--- a/Bonsai.Sleap/PredictLabeledPoses.cs
+++ b/Bonsai.Sleap/PredictLabeledPoses.cs
@@ -43,7 +43,7 @@ namespace Bonsai.Sleap
         [Description("The optional color conversion used to prepare RGB video frames for inference.")]
         public ColorConversion? ColorConversion { get; set; }
 
-        public IObservable<LabeledPoseCollection> Process(IObservable<IplImage[]> source)
+        private IObservable<LabeledPoseCollection> Process(IObservable<IplImage[]> source)
         {
             return Observable.Defer(() =>
             {

--- a/Bonsai.Sleap/PredictLabeledPoses.cs
+++ b/Bonsai.Sleap/PredictLabeledPoses.cs
@@ -97,7 +97,8 @@ namespace Bonsai.Sleap
                     TensorHelper.UpdateTensor(tensor, colorChannels, frames);
                     var output = runner.Run();
 
-                    if (output[0].Shape[0] == 0) return new LabeledPoseCollection();
+                    var identityCollection = new LabeledPoseCollection(input[0]);
+                    if (output[0].Shape[0] == 0) return identityCollection;
                     else
                     {
                         // Fetch the results from output
@@ -121,7 +122,6 @@ namespace Bonsai.Sleap
                         float[,] idArr = new float[idTensor.Shape[0], idTensor.Shape[1]];
                         idTensor.GetValue(idArr);
 
-                        var identityCollection = new LabeledPoseCollection();
                         var partThreshold = PartMinConfidence;
                         var idThreshold = IdentityMinConfidence;
                         var centroidTreshold = CentroidMinConfidence;

--- a/Bonsai.Sleap/PredictPoses.cs
+++ b/Bonsai.Sleap/PredictPoses.cs
@@ -119,8 +119,8 @@ namespace Bonsai.Sleap
                         for (int i = 0; i < input.Length; i++)
                         {
                             var pose = new Pose(input[0]);
-                            var centroid = new Centroid(input[0]);
-
+                            var centroid = new BodyPart();
+                            centroid.Name = string.Empty;
                             centroid.Confidence = centroidConfArr[0];
                             if (centroid.Confidence < centroidThreshold)
                             {
@@ -137,7 +137,7 @@ namespace Bonsai.Sleap
                             // Iterate on the body parts
                             for (int bodyPartIdx = 0; bodyPartIdx < poseArr.GetLength(1); bodyPartIdx++)
                             {
-                                BodyPart bodyPart;
+                                var bodyPart = new BodyPart();
                                 bodyPart.Name = config.PartNames[bodyPartIdx];
                                 bodyPart.Confidence = partConfArr[i, bodyPartIdx];
                                 if (bodyPart.Confidence < partThreshold)

--- a/Bonsai.Sleap/PredictPoses.cs
+++ b/Bonsai.Sleap/PredictPoses.cs
@@ -116,7 +116,7 @@ namespace Bonsai.Sleap
                         var centroidThreshold = CentroidMinConfidence;
 
                         //Loop the available identifications
-                        for (int i = 0; i < input.Length; i++)
+                        for (int i = 0; i < centroidArr.GetLength(0); i++)
                         {
                             var pose = new Pose(input[0]);
                             var centroid = new BodyPart();

--- a/Bonsai.Sleap/PredictPoses.cs
+++ b/Bonsai.Sleap/PredictPoses.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Reactive.Linq;
 using OpenCV.Net;
@@ -37,7 +37,7 @@ namespace Bonsai.Sleap
         [Description("The optional color conversion used to prepare RGB video frames for inference.")]
         public ColorConversion? ColorConversion { get; set; }
 
-        public IObservable<PoseCollection> Process(IObservable<IplImage[]> source)
+        private IObservable<PoseCollection> Process(IObservable<IplImage[]> source)
         {
             return Observable.Defer(() =>
             {

--- a/Bonsai.Sleap/PredictPoses.cs
+++ b/Bonsai.Sleap/PredictPoses.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Reactive.Linq;
 using OpenCV.Net;
@@ -92,7 +92,8 @@ namespace Bonsai.Sleap
                     TensorHelper.UpdateTensor(tensor, colorChannels, frames);
                     var output = runner.Run();
 
-                    if (output[0].Shape[0] == 0) return new PoseCollection();
+                    var poseCollection = new PoseCollection(input[0]);
+                    if (output[0].Shape[0] == 0) return poseCollection;
                     else
                     {
                         var centroidConfidenceTensor = output[0];
@@ -111,7 +112,6 @@ namespace Bonsai.Sleap
                         float[,,] poseArr = new float[poseTensor.Shape[0], poseTensor.Shape[1], poseTensor.Shape[2]];
                         poseTensor.GetValue(poseArr);
 
-                        var poseCollection = new PoseCollection();
                         var partThreshold = PartMinConfidence;
                         var centroidThreshold = CentroidMinConfidence;
 

--- a/Bonsai.Sleap/PredictSinglePose.cs
+++ b/Bonsai.Sleap/PredictSinglePose.cs
@@ -100,7 +100,7 @@ namespace Bonsai.Sleap
                         // Iterate on the body parts
                         for (int bodyPartIdx = 0; bodyPartIdx < poseArr.GetLength(2); bodyPartIdx++)
                         {
-                            BodyPart bodyPart;
+                            var bodyPart = new BodyPart();
                             bodyPart.Name = config.PartNames[bodyPartIdx];
                             bodyPart.Confidence = partConfArr[i,0, bodyPartIdx];
                             if (bodyPart.Confidence < partThreshold)

--- a/Bonsai.Sleap/PredictSinglePose.cs
+++ b/Bonsai.Sleap/PredictSinglePose.cs
@@ -4,6 +4,7 @@ using System.Reactive.Linq;
 using OpenCV.Net;
 using TensorFlow;
 using System.ComponentModel;
+using System.Collections.Generic;
 
 namespace Bonsai.Sleap
 {
@@ -32,7 +33,7 @@ namespace Bonsai.Sleap
         [Description("The optional color conversion used to prepare RGB video frames for inference.")]
         public ColorConversion? ColorConversion { get; set; }
 
-        public IObservable<PoseCollection> Process(IObservable<IplImage[]> source)
+        public IObservable<IList<Pose>> Process(IObservable<IplImage[]> source)
         {
             return Observable.Defer(() =>
             {
@@ -90,7 +91,7 @@ namespace Bonsai.Sleap
                     float[,,,] poseArr = new float[poseTensor.Shape[0], poseTensor.Shape[1], poseTensor.Shape[2], poseTensor.Shape[3]];
                     poseTensor.GetValue(poseArr);
 
-                    var poseCollection = new PoseCollection();
+                    var poseCollection = new List<Pose>();
                     var partThreshold = PartMinConfidence;
 
                     //Loop the available identifications


### PR DESCRIPTION
This PR tries to fix #4.
- Adds a visualizer for the collections of labeled poses (LabeledPoseCollection). 
- For each instance, all body parts are used to calculate a bounding box which is then dilated by a fixed factor. The bounding box is shown around each animal with a unique color. 
- The instance's label name is also added to one of the corners of the roi.
