### PR TITLE
Add `IdentityIndex` property to `PoseIdentity`

### DIFF
--- a/src/Bonsai.Sleap/Bonsai.Sleap.csproj
+++ b/src/Bonsai.Sleap/Bonsai.Sleap.csproj
@@ -6,7 +6,7 @@
     <PackageTags>Bonsai Rx SLEAP LEAP Markerless Multi Pose Tracking</PackageTags>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TargetFramework>net472</TargetFramework>
-    <VersionPrefix>0.1.0</VersionPrefix>
+    <VersionPrefix>0.2.0</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Bonsai.Sleap/PoseIdentity.cs
+++ b/src/Bonsai.Sleap/PoseIdentity.cs
@@ -25,7 +25,7 @@ namespace Bonsai.Sleap
         public string Identity { get; set; }
 
         /// <summary>
-        /// Gets or sets the predicted pose index identity.
+        /// Gets or sets the predicted pose identity index.
         /// </summary>
         [XmlIgnore]
         public int IdentityIndex { get; set; }
@@ -34,7 +34,5 @@ namespace Bonsai.Sleap
         /// Gets or sets the confidence score for the predicted identity.
         /// </summary>
         public float Confidence { get; set; }
-
-
     }
 }

--- a/src/Bonsai.Sleap/PoseIdentity.cs
+++ b/src/Bonsai.Sleap/PoseIdentity.cs
@@ -1,4 +1,5 @@
-﻿using OpenCV.Net;
+﻿using System.Xml.Serialization;
+using OpenCV.Net;
 
 namespace Bonsai.Sleap
 {
@@ -24,8 +25,16 @@ namespace Bonsai.Sleap
         public string Identity { get; set; }
 
         /// <summary>
+        /// Gets or sets the predicted pose index identity.
+        /// </summary>
+        [XmlIgnore]
+        public int IdentityIndex { get; set; }
+
+        /// <summary>
         /// Gets or sets the confidence score for the predicted identity.
         /// </summary>
         public float Confidence { get; set; }
+
+
     }
 }

--- a/src/Bonsai.Sleap/PredictPoseIdentities.cs
+++ b/src/Bonsai.Sleap/PredictPoseIdentities.cs
@@ -170,13 +170,19 @@ namespace Bonsai.Sleap
                             // Find the class with max score
                             var pose = new PoseIdentity(input.Length == 1 ? input[0] : input[iid]);
                             var maxIndex = ArgMax(idArr, iid, Comparer<float>.Default, out float maxScore);
-                            pose.IdentityIndex = maxIndex;
-                            pose.Confidence = maxScore;
+
                             if (maxScore < idThreshold || maxIndex < 0)
                             {
+                                pose.IdentityIndex = -1;
+                                pose.Confidence = float.NaN;
                                 pose.Identity = string.Empty;
                             }
-                            else pose.Identity = config.ClassNames[maxIndex];
+                            else
+                            {
+                                pose.IdentityIndex = maxIndex;
+                                pose.Confidence = maxScore;
+                                pose.Identity = config.ClassNames[maxIndex];
+                            }
 
                             var centroid = new BodyPart();
                             centroid.Name = config.AnchorName;

--- a/src/Bonsai.Sleap/PredictPoseIdentities.cs
+++ b/src/Bonsai.Sleap/PredictPoseIdentities.cs
@@ -105,7 +105,7 @@ namespace Bonsai.Sleap
                     var tensorSize = input[0].Size;
                     var batchSize = input.Length;
                     var scaleFactor = ScaleFactor;
-                    
+
                     if (scaleFactor.HasValue)
                     {
                         poseScale = scaleFactor.Value;
@@ -121,7 +121,7 @@ namespace Bonsai.Sleap
                         tensor = TensorHelper.CreatePlaceholder(graph, runner, tensorSize, batchSize, colorChannels);
 
                         runner.Fetch(graph["Identity"][0]);
-                        runner.Fetch(graph["Identity_2"][0]); 
+                        runner.Fetch(graph["Identity_2"][0]);
                         runner.Fetch(graph["Identity_4"][0]);
                         runner.Fetch(graph["Identity_5"][0]);
                         runner.Fetch(graph["Identity_6"][0]);

--- a/src/Bonsai.Sleap/PredictPoseIdentities.cs
+++ b/src/Bonsai.Sleap/PredictPoseIdentities.cs
@@ -170,6 +170,7 @@ namespace Bonsai.Sleap
                             // Find the class with max score
                             var pose = new PoseIdentity(input.Length == 1 ? input[0] : input[iid]);
                             var maxIndex = ArgMax(idArr, iid, Comparer<float>.Default, out float maxScore);
+                            pose.IdentityIndex = maxIndex;
                             pose.Confidence = maxScore;
                             if (maxScore < idThreshold || maxIndex < 0)
                             {


### PR DESCRIPTION
This PR adds an extra field to the `PoseIdentity` class that stores the `ArgMax` value from the Identity inference output vector when running the `PredictPoseIdentities` operator:

https://github.com/bonsai-rx/sleap/blob/c4a3e19ed2c76f0076757a0d25c6d88925d9e04f/src/Bonsai.Sleap/PredictPoseIdentities.cs#L172

This value is useful when the user wants to store the output of the network in a non-text format such as a flat binary file or HarpMessage objects.

For full backward compatibility, an `[XmlIgnore]` attribute was added to the property, guaranteeing that downstream operations', namely text-based logging using `CsvWriter`, behavior remains unchanged.

Finally, if the operator's property `IdentityMinConfidence` is greater than the inferred maximum confidence, the `PoseIdentity` class will be returned as:

```
IdentityIndex = -1
Confidence = float.NaN;
Identity = string.Empty;
```
