### PR TITLE
Ensure identity index is set on default pose

### DIFF
--- a/src/Bonsai.Sleap/Bonsai.Sleap.csproj
+++ b/src/Bonsai.Sleap/Bonsai.Sleap.csproj
@@ -6,7 +6,7 @@
     <PackageTags>Bonsai Rx SLEAP LEAP Markerless Multi Pose Tracking</PackageTags>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TargetFramework>net472</TargetFramework>
-    <VersionPrefix>0.2.0</VersionPrefix>
+    <VersionPrefix>0.2.1</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Bonsai.Sleap/GetMaximumConfidencePoseIdentity.cs
+++ b/src/Bonsai.Sleap/GetMaximumConfidencePoseIdentity.cs
@@ -60,6 +60,7 @@ namespace Bonsai.Sleap
         {
             return new PoseIdentity(image)
             {
+                IdentityIndex = -1,
                 Identity = identity,
                 Confidence = float.NaN,
                 Centroid = GetBodyPart.DefaultBodyPart(string.Empty)


### PR DESCRIPTION
This PR ensures that identity index is set to an invalid value of `-1` when `GetMaximumConfidencePoseIdentity` fails to find the specified identity in the collection. This is consistent with the behavior in `PredictPoseIdentities` and will avoid confusion when logging this numeric field.

Fixes #16 