### PR TITLE
Update frozen graph import to support both ragged and unragged tensors

### DIFF
--- a/src/Bonsai.Sleap/PredictCentroids.cs
+++ b/src/Bonsai.Sleap/PredictCentroids.cs
@@ -71,6 +71,7 @@ namespace Bonsai.Sleap
                 TFSession.Runner runner = null;
                 var graph = TensorHelper.ImportModel(ModelFileName, out TFSession session);
                 var config = ConfigHelper.LoadTrainingConfig(TrainingConfig);
+                bool ragged = true;
 
                 if (config.ModelType != ModelType.Centroid)
                 {
@@ -96,11 +97,32 @@ namespace Bonsai.Sleap
                     if (tensor == null || tensor.Shape[0] != batchSize || tensor.Shape[1] != tensorSize.Height || tensor.Shape[2] != tensorSize.Width)
                     {
                         tensor?.Dispose();
+                        try
+                        {
+                            session.GetRunner().Fetch(graph["Identity_6"][0]);
+                        }
+                        catch (Exception e)
+                        {
+                            ragged = false;
+                        }
+
                         runner = session.GetRunner();
                         tensor = TensorHelper.CreatePlaceholder(graph, runner, tensorSize, batchSize, colorChannels);
 
-                        runner.Fetch(graph["Identity"][0]);
-                        runner.Fetch(graph["Identity_1"][0]);
+                        // ragged version of the frozen graph
+                        if (ragged)
+                        {
+                            runner.Fetch(graph["Identity"][0]);
+                            runner.Fetch(graph["Identity_2"][0]);
+                        }
+
+                        // unragged version of the frozen graph
+                        if (!ragged)
+                        {
+                            runner.Fetch(graph["Identity"][0]);
+                            runner.Fetch(graph["Identity_1"][0]);
+                        }
+                            
                     }
 
                     var frames = Array.ConvertAll(input, frame =>
@@ -113,39 +135,79 @@ namespace Bonsai.Sleap
                     var output = runner.Run();
 
                     var centroidCollection = new CentroidCollection(input[0]);
-                    if (output[0].Shape[1] == 0) return centroidCollection;
+                    if (!ragged)
+                    {
+                        if (output[0].Shape[1] == 0) return centroidCollection;
+                        else
+                        {
+                            // Fetch the results from output
+                            var centroidConfidenceTensor = output[0];
+                            float[,] centroidConfArr = new float[centroidConfidenceTensor.Shape[0], centroidConfidenceTensor.Shape[1]];
+                            centroidConfidenceTensor.GetValue(centroidConfArr);
+
+                            var centroidTensor = output[1];
+                            float[,,] centroidArr = new float[centroidTensor.Shape[0], centroidTensor.Shape[1], centroidTensor.Shape[2]];
+                            centroidTensor.GetValue(centroidArr);
+
+                            var confidenceThreshold = CentroidMinConfidence;
+                            for (int i = 0; i < centroidConfArr.GetLength(1); i++)
+                            {
+                                //TODO: batch centroid estimation is not currently supported
+                                var centroid = new Centroid(input[0]);
+                                centroid.Name = config.AnchorName;
+                                centroid.Confidence = centroidConfArr[0, i];
+
+                                if (centroid.Confidence < confidenceThreshold)
+                                {
+                                    centroid.Position = new Point2f(float.NaN, float.NaN);
+                                }
+                                else
+                                {
+                                    centroid.Position = new Point2f(
+                                        (float)(centroidArr[0, i, 0] * poseScale),
+                                        (float)(centroidArr[0, i, 1] * poseScale));
+                                }
+                                centroidCollection.Add(centroid);
+                            };
+                            return centroidCollection;
+                        }
+                    }
                     else
                     {
-                        // Fetch the results from output
-                        var centroidConfidenceTensor = output[0];
-                        float[,] centroidConfArr = new float[centroidConfidenceTensor.Shape[0], centroidConfidenceTensor.Shape[1]];
-                        centroidConfidenceTensor.GetValue(centroidConfArr);
-
-                        var centroidTensor = output[1];
-                        float[,,] centroidArr = new float[centroidTensor.Shape[0], centroidTensor.Shape[1], centroidTensor.Shape[2]];
-                        centroidTensor.GetValue(centroidArr);
-
-                        var confidenceThreshold = CentroidMinConfidence;
-                        for (int i = 0; i < centroidConfArr.GetLength(1); i++)
+                        if (output[0].Shape[0] == 0) return centroidCollection;
+                        else
                         {
-                            //TODO: batch centroid estimation is not currently supported
-                            var centroid = new Centroid(input[0]);
-                            centroid.Name = config.AnchorName;
-                            centroid.Confidence = centroidConfArr[0, i];
+                            // Fetch the results from output
+                            var centroidConfidenceTensor = output[0];
+                            float[] centroidConfArr = new float[centroidConfidenceTensor.Shape[0]];
+                            centroidConfidenceTensor.GetValue(centroidConfArr);
 
-                            if (centroid.Confidence < confidenceThreshold)
+                            var centroidTensor = output[1];
+                            float[,] centroidArr = new float[centroidTensor.Shape[0], centroidTensor.Shape[1]];
+                            centroidTensor.GetValue(centroidArr);
+
+                            var confidenceThreshold = CentroidMinConfidence;
+                            for (int i = 0; i < centroidConfArr.GetLength(0); i++)
                             {
-                                centroid.Position = new Point2f(float.NaN, float.NaN);
-                            }
-                            else
-                            {
-                                centroid.Position = new Point2f(
-                                    (float)(centroidArr[0, i, 0] * poseScale),
-                                    (float)(centroidArr[0, i, 1] * poseScale));
-                            }
-                            centroidCollection.Add(centroid);
-                        };
-                        return centroidCollection;
+                                //TODO: batch centroid estimation is not currently supported
+                                var centroid = new Centroid(input[0]);
+                                centroid.Name = config.AnchorName;
+                                centroid.Confidence = centroidConfArr[i];
+
+                                if (centroid.Confidence < confidenceThreshold)
+                                {
+                                    centroid.Position = new Point2f(float.NaN, float.NaN);
+                                }
+                                else
+                                {
+                                    centroid.Position = new Point2f(
+                                        (float)(centroidArr[i, 0] * poseScale),
+                                        (float)(centroidArr[i, 1] * poseScale));
+                                }
+                                centroidCollection.Add(centroid);
+                            };
+                            return centroidCollection;
+                        }
                     }
                 });
             });

--- a/src/Bonsai.Sleap/PredictCentroids.cs
+++ b/src/Bonsai.Sleap/PredictCentroids.cs
@@ -131,11 +131,11 @@ namespace Bonsai.Sleap
                         // Fetch the results from output
                         var centroidConfidenceTensor = output[0];
                         float[] centroidConfArr = new float[centroidConfidenceTensor.Shape[shapeIdx]];
-                        centroidConfidenceTensor.GetValue(centroidConfArr);
+                        TensorHelper.GetTensorValue(centroidConfidenceTensor, centroidConfArr);
 
                         var centroidTensor = output[1];
                         float[,] centroidArr = new float[centroidTensor.Shape[shapeIdx], centroidTensor.Shape[shapeIdx + 1]];
-                        centroidTensor.GetValue(centroidArr);
+                        TensorHelper.GetTensorValue(centroidTensor, centroidArr);
 
                         var confidenceThreshold = CentroidMinConfidence;
                         for (int i = 0; i < centroidConfArr.GetLength(0); i++)

--- a/src/Bonsai.Sleap/PredictCentroids.cs
+++ b/src/Bonsai.Sleap/PredictCentroids.cs
@@ -71,7 +71,7 @@ namespace Bonsai.Sleap
                 TFSession.Runner runner = null;
                 var graph = TensorHelper.ImportModel(ModelFileName, out TFSession session);
                 var config = ConfigHelper.LoadTrainingConfig(TrainingConfig);
-                var ragged = graph["Identity_2"] != null;
+                var ragged = graph["Identity_6"] != null;
 
                 if (config.ModelType != ModelType.Centroid)
                 {

--- a/src/Bonsai.Sleap/PredictPoseIdentities.cs
+++ b/src/Bonsai.Sleap/PredictPoseIdentities.cs
@@ -158,23 +158,23 @@ namespace Bonsai.Sleap
                         // Fetch the results from output
                         var centroidConfidenceTensor = output[0];
                         float[] centroidConfArr = new float[centroidConfidenceTensor.Shape[shapeIdx]];
-                        centroidConfidenceTensor.GetValue(centroidConfArr);
+                        TensorHelper.GetTensorValue(centroidConfidenceTensor, centroidConfArr);
 
                         var centroidTensor = output[1];
                         float[,] centroidArr = new float[centroidTensor.Shape[shapeIdx], centroidTensor.Shape[shapeIdx + 1]];
-                        centroidTensor.GetValue(centroidArr);
+                        TensorHelper.GetTensorValue(centroidTensor, centroidArr);
 
                         var partConfTensor = output[2];
                         float[,] partConfArr = new float[partConfTensor.Shape[shapeIdx], partConfTensor.Shape[shapeIdx + 1]];
-                        partConfTensor.GetValue(partConfArr);
+                        TensorHelper.GetTensorValue(partConfTensor, partConfArr);
 
                         var poseTensor = output[3];
                         float[,,] poseArr = new float[poseTensor.Shape[shapeIdx], poseTensor.Shape[shapeIdx + 1], poseTensor.Shape[shapeIdx + 2]];
-                        poseTensor.GetValue(poseArr);
+                        TensorHelper.GetTensorValue(poseTensor, poseArr);
 
                         var idTensor = output[4];
                         float[,] idArr = new float[idTensor.Shape[shapeIdx], idTensor.Shape[shapeIdx + 1]];
-                        idTensor.GetValue(idArr);
+                        TensorHelper.GetTensorValue(idTensor, idArr);
 
                         var partThreshold = PartMinConfidence;
                         var idThreshold = IdentityMinConfidence;

--- a/src/Bonsai.Sleap/PredictPoseIdentities.cs
+++ b/src/Bonsai.Sleap/PredictPoseIdentities.cs
@@ -165,15 +165,15 @@ namespace Bonsai.Sleap
                         TensorHelper.GetTensorValue(centroidTensor, centroidArr);
 
                         var partConfTensor = output[2];
-                        float[,] partConfArr = new float[partConfTensor.Shape[shapeIdx], partConfTensor.Shape[shapeIdx + 1]];
+                        float[,] partConfArr = new float[partConfTensor.Shape[0], partConfTensor.Shape[1]];
                         TensorHelper.GetTensorValue(partConfTensor, partConfArr);
 
                         var poseTensor = output[3];
-                        float[,,] poseArr = new float[poseTensor.Shape[shapeIdx], poseTensor.Shape[shapeIdx + 1], poseTensor.Shape[shapeIdx + 2]];
+                        float[,,] poseArr = new float[poseTensor.Shape[0], poseTensor.Shape[1], poseTensor.Shape[2]];
                         TensorHelper.GetTensorValue(poseTensor, poseArr);
 
                         var idTensor = output[4];
-                        float[,] idArr = new float[idTensor.Shape[shapeIdx], idTensor.Shape[shapeIdx + 1]];
+                        float[,] idArr = new float[idTensor.Shape[0], idTensor.Shape[1]];
                         TensorHelper.GetTensorValue(idTensor, idArr);
 
                         var partThreshold = PartMinConfidence;

--- a/src/Bonsai.Sleap/PredictPoseIdentities.cs
+++ b/src/Bonsai.Sleap/PredictPoseIdentities.cs
@@ -92,6 +92,7 @@ namespace Bonsai.Sleap
                 TFSession.Runner runner = null;
                 var graph = TensorHelper.ImportModel(ModelFileName, out TFSession session);
                 var config = ConfigHelper.LoadTrainingConfig(TrainingConfig);
+                bool ragged = true;
 
                 if (config.ModelType != ModelType.MultiClass)
                 {
@@ -117,14 +118,38 @@ namespace Bonsai.Sleap
                     if (tensor == null || tensor.Shape[0] != batchSize || tensor.Shape[1] != tensorSize.Height || tensor.Shape[2] != tensorSize.Width)
                     {
                         tensor?.Dispose();
+                        try
+                        {
+                            session.GetRunner().Fetch(graph["Identity_6"][0]);
+                        }
+                        catch (Exception e)
+                        {
+                            ragged = false;
+                        }
+
                         runner = session.GetRunner();
                         tensor = TensorHelper.CreatePlaceholder(graph, runner, tensorSize, batchSize, colorChannels);
 
-                        runner.Fetch(graph["Identity"][0]);
-                        runner.Fetch(graph["Identity_1"][0]);
-                        runner.Fetch(graph["Identity_2"][0]);
-                        runner.Fetch(graph["Identity_3"][0]);
-                        runner.Fetch(graph["Identity_4"][0]);
+                        // ragged version of the frozen graph
+                        if (ragged)
+                        {
+                           
+                            runner.Fetch(graph["Identity"][0]);
+                            runner.Fetch(graph["Identity_2"][0]);
+                            runner.Fetch(graph["Identity_4"][0]);
+                            runner.Fetch(graph["Identity_5"][0]);
+                            runner.Fetch(graph["Identity_6"][0]);
+                        }
+
+                        // unragged version of the frozen graph
+                        if (!ragged)
+                        {
+                            runner.Fetch(graph["Identity"][0]);
+                            runner.Fetch(graph["Identity_1"][0]);
+                            runner.Fetch(graph["Identity_2"][0]);
+                            runner.Fetch(graph["Identity_3"][0]);
+                            runner.Fetch(graph["Identity_4"][0]);
+                        } 
 
                     }
 
@@ -138,90 +163,183 @@ namespace Bonsai.Sleap
                     var output = runner.Run();
 
                     var identityCollection = new PoseIdentityCollection(input[0]);
-                    if (output[0].Shape[1] == 0) return identityCollection;
-                    else
+                    // non ragged version of the frozen graph
+                    if (!ragged)
                     {
-                        // Fetch the results from output
-                        var centroidConfidenceTensor = output[0];
-                        float[,] centroidConfArr = new float[centroidConfidenceTensor.Shape[0], centroidConfidenceTensor.Shape[1]];
-                        centroidConfidenceTensor.GetValue(centroidConfArr);
-
-                        var centroidTensor = output[1];
-                        float[,,] centroidArr = new float[centroidTensor.Shape[0], centroidTensor.Shape[1], centroidTensor.Shape[2]];
-                        centroidTensor.GetValue(centroidArr);
-
-                        var partConfTensor = output[2];
-                        float[,] partConfArr = new float[partConfTensor.Shape[0], partConfTensor.Shape[1]];
-                        partConfTensor.GetValue(partConfArr);
-
-                        var poseTensor = output[3];
-                        float[,,] poseArr = new float[poseTensor.Shape[0], poseTensor.Shape[1], poseTensor.Shape[2]];
-                        poseTensor.GetValue(poseArr);
-
-                        var idTensor = output[4];
-                        float[,] idArr = new float[idTensor.Shape[0], idTensor.Shape[1]];
-                        idTensor.GetValue(idArr);
-
-                        var partThreshold = PartMinConfidence;
-                        var idThreshold = IdentityMinConfidence;
-                        var centroidThreshold = CentroidMinConfidence;
-
-                        for (int iid = 0; iid < idArr.GetLength(0); iid++)
+                        if (output[0].Shape[1] == 0) return identityCollection;
+                        else
                         {
-                            // Find the class with max score
-                            var pose = new PoseIdentity(input.Length == 1 ? input[0] : input[iid]);
-                            var maxIndex = ArgMax(idArr, iid, Comparer<float>.Default, out float maxScore);
+                            // Fetch the results from output
+                            var centroidConfidenceTensor = output[0];
+                            float[,] centroidConfArr = new float[centroidConfidenceTensor.Shape[0], centroidConfidenceTensor.Shape[1]];
+                            centroidConfidenceTensor.GetValue(centroidConfArr);
 
-                            if (maxScore < idThreshold || maxIndex < 0)
-                            {
-                                pose.IdentityIndex = -1;
-                                pose.Confidence = float.NaN;
-                                pose.Identity = string.Empty;
-                            }
-                            else
-                            {
-                                pose.IdentityIndex = maxIndex;
-                                pose.Confidence = maxScore;
-                                pose.Identity = config.ClassNames[maxIndex];
-                            }
+                            var centroidTensor = output[1];
+                            float[,,] centroidArr = new float[centroidTensor.Shape[0], centroidTensor.Shape[1], centroidTensor.Shape[2]];
+                            centroidTensor.GetValue(centroidArr);
 
-                            var centroid = new BodyPart();
-                            centroid.Name = config.AnchorName;
-                            centroid.Confidence = centroidConfArr[0, 0];
-                            if (centroid.Confidence < centroidThreshold)
-                            {
-                                centroid.Position = new Point2f(float.NaN, float.NaN);
-                            }
-                            else
-                            {
-                                centroid.Position = new Point2f(
-                                    x: (float)(centroidArr[0, iid, 0] * poseScale),
-                                    y: (float)(centroidArr[0, iid, 1] * poseScale));
-                            }
-                            pose.Centroid = centroid;
+                            var partConfTensor = output[2];
+                            float[,] partConfArr = new float[partConfTensor.Shape[0], partConfTensor.Shape[1]];
+                            partConfTensor.GetValue(partConfArr);
 
-                            // Iterate on the body parts
-                            for (int bodyPartIdx = 0; bodyPartIdx < poseArr.GetLength(1); bodyPartIdx++)
+                            var poseTensor = output[3];
+                            float[,,] poseArr = new float[poseTensor.Shape[0], poseTensor.Shape[1], poseTensor.Shape[2]];
+                            poseTensor.GetValue(poseArr);
+
+                            var idTensor = output[4];
+                            float[,] idArr = new float[idTensor.Shape[0], idTensor.Shape[1]];
+                            idTensor.GetValue(idArr);
+
+                            var partThreshold = PartMinConfidence;
+                            var idThreshold = IdentityMinConfidence;
+                            var centroidThreshold = CentroidMinConfidence;
+
+                            for (int iid = 0; iid < idArr.GetLength(0); iid++)
                             {
-                                var bodyPart = new BodyPart();
-                                bodyPart.Name = config.PartNames[bodyPartIdx];
-                                bodyPart.Confidence = partConfArr[iid, bodyPartIdx];
-                                if (bodyPart.Confidence < partThreshold)
+                                // Find the class with max score
+                                var pose = new PoseIdentity(input.Length == 1 ? input[0] : input[iid]);
+                                var maxIndex = ArgMax(idArr, iid, Comparer<float>.Default, out float maxScore);
+
+                                if (maxScore < idThreshold || maxIndex < 0)
                                 {
-                                    bodyPart.Position = new Point2f(float.NaN, float.NaN);
+                                    pose.IdentityIndex = -1;
+                                    pose.Confidence = float.NaN;
+                                    pose.Identity = string.Empty;
                                 }
                                 else
                                 {
-                                    bodyPart.Position = new Point2f(
-                                        x: (float)(poseArr[iid, bodyPartIdx, 0] * poseScale),
-                                        y: (float)(poseArr[iid, bodyPartIdx, 1] * poseScale));
+                                    pose.IdentityIndex = maxIndex;
+                                    pose.Confidence = maxScore;
+                                    pose.Identity = config.ClassNames[maxIndex];
                                 }
-                                pose.Add(bodyPart);
-                            }
-                            identityCollection.Add(pose);
-                        };
-                        return identityCollection;
+
+                                var centroid = new BodyPart();
+                                centroid.Name = config.AnchorName;
+                                centroid.Confidence = centroidConfArr[0, 0];
+                                if (centroid.Confidence < centroidThreshold)
+                                {
+                                    centroid.Position = new Point2f(float.NaN, float.NaN);
+                                }
+                                else
+                                {
+                                    centroid.Position = new Point2f(
+                                        x: (float)(centroidArr[0, iid, 0] * poseScale),
+                                        y: (float)(centroidArr[0, iid, 1] * poseScale));
+                                }
+                                pose.Centroid = centroid;
+
+                                // Iterate on the body parts
+                                for (int bodyPartIdx = 0; bodyPartIdx < poseArr.GetLength(1); bodyPartIdx++)
+                                {
+                                    var bodyPart = new BodyPart();
+                                    bodyPart.Name = config.PartNames[bodyPartIdx];
+                                    bodyPart.Confidence = partConfArr[iid, bodyPartIdx];
+                                    if (bodyPart.Confidence < partThreshold)
+                                    {
+                                        bodyPart.Position = new Point2f(float.NaN, float.NaN);
+                                    }
+                                    else
+                                    {
+                                        bodyPart.Position = new Point2f(
+                                            x: (float)(poseArr[iid, bodyPartIdx, 0] * poseScale),
+                                            y: (float)(poseArr[iid, bodyPartIdx, 1] * poseScale));
+                                    }
+                                    pose.Add(bodyPart);
+                                }
+                                identityCollection.Add(pose);
+                            };
+                            return identityCollection;
+                        }
                     }
+                    // ragged version
+                    else
+                    {
+                        if (output[0].Shape[0] == 0) return identityCollection;
+                        else
+                        {
+                            // Fetch the results from output
+                            var centroidConfidenceTensor = output[0];
+                            float[] centroidConfArr = new float[centroidConfidenceTensor.Shape[0]];
+                            centroidConfidenceTensor.GetValue(centroidConfArr);
+
+                            var centroidTensor = output[1];
+                            float[,] centroidArr = new float[centroidTensor.Shape[0], centroidTensor.Shape[1]];
+                            centroidTensor.GetValue(centroidArr);
+
+                            var partConfTensor = output[2];
+                            float[,] partConfArr = new float[partConfTensor.Shape[0], partConfTensor.Shape[1]];
+                            partConfTensor.GetValue(partConfArr);
+
+                            var poseTensor = output[3];
+                            float[,,] poseArr = new float[poseTensor.Shape[0], poseTensor.Shape[1], poseTensor.Shape[2]];
+                            poseTensor.GetValue(poseArr);
+
+                            var idTensor = output[4];
+                            float[,] idArr = new float[idTensor.Shape[0], idTensor.Shape[1]];
+                            idTensor.GetValue(idArr);
+
+                            var partThreshold = PartMinConfidence;
+                            var idThreshold = IdentityMinConfidence;
+                            var centroidThreshold = CentroidMinConfidence;
+
+                            for (int iid = 0; iid < idArr.GetLength(0); iid++)
+                            {
+                                // Find the class with max score
+                                var pose = new PoseIdentity(input.Length == 1 ? input[0] : input[iid]);
+                                var maxIndex = ArgMax(idArr, iid, Comparer<float>.Default, out float maxScore);
+
+                                if (maxScore < idThreshold || maxIndex < 0)
+                                {
+                                    pose.IdentityIndex = -1;
+                                    pose.Confidence = float.NaN;
+                                    pose.Identity = string.Empty;
+                                }
+                                else
+                                {
+                                    pose.IdentityIndex = maxIndex;
+                                    pose.Confidence = maxScore;
+                                    pose.Identity = config.ClassNames[maxIndex];
+                                }
+
+                                var centroid = new BodyPart();
+                                centroid.Name = config.AnchorName;
+                                centroid.Confidence = centroidConfArr[0];
+                                if (centroid.Confidence < centroidThreshold)
+                                {
+                                    centroid.Position = new Point2f(float.NaN, float.NaN);
+                                }
+                                else
+                                {
+                                    centroid.Position = new Point2f(
+                                        x: (float)(centroidArr[iid, 0] * poseScale),
+                                        y: (float)(centroidArr[iid, 1] * poseScale));
+                                }
+                                pose.Centroid = centroid;
+
+                                // Iterate on the body parts
+                                for (int bodyPartIdx = 0; bodyPartIdx < poseArr.GetLength(1); bodyPartIdx++)
+                                {
+                                    var bodyPart = new BodyPart();
+                                    bodyPart.Name = config.PartNames[bodyPartIdx];
+                                    bodyPart.Confidence = partConfArr[iid, bodyPartIdx];
+                                    if (bodyPart.Confidence < partThreshold)
+                                    {
+                                        bodyPart.Position = new Point2f(float.NaN, float.NaN);
+                                    }
+                                    else
+                                    {
+                                        bodyPart.Position = new Point2f(
+                                            x: (float)(poseArr[iid, bodyPartIdx, 0] * poseScale),
+                                            y: (float)(poseArr[iid, bodyPartIdx, 1] * poseScale));
+                                    }
+                                    pose.Add(bodyPart);
+                                }
+                                identityCollection.Add(pose);
+                            };
+                            return identityCollection;
+                        }
+                    }
+                    
                 });
             });
         }

--- a/src/Bonsai.Sleap/PredictPoses.cs
+++ b/src/Bonsai.Sleap/PredictPoses.cs
@@ -144,19 +144,19 @@ namespace Bonsai.Sleap
                     {
                         var centroidConfidenceTensor = output[0];
                         float[] centroidConfArr = new float[centroidConfidenceTensor.Shape[shapeIdx]];
-                        centroidConfidenceTensor.GetValue(centroidConfArr);
+                        TensorHelper.GetTensorValue(centroidConfidenceTensor, centroidConfArr);
 
                         var centroidTensor = output[1];
                         float[,] centroidArr = new float[centroidTensor.Shape[shapeIdx], centroidTensor.Shape[shapeIdx + 1]];
-                        centroidTensor.GetValue(centroidArr);
+                        TensorHelper.GetTensorValue(centroidTensor, centroidArr);
 
                         var partConfTensor = output[2];
                         float[,] partConfArr = new float[partConfTensor.Shape[shapeIdx], partConfTensor.Shape[shapeIdx + 1]];
-                        partConfTensor.GetValue(partConfArr);
+                        TensorHelper.GetTensorValue(partConfTensor, partConfArr);
 
                         var poseTensor = output[3];
                         float[,,] poseArr = new float[poseTensor.Shape[shapeIdx], poseTensor.Shape[shapeIdx + 1], poseTensor.Shape[shapeIdx + 2]];
-                        poseTensor.GetValue(poseArr);
+                        TensorHelper.GetTensorValue(poseTensor, poseArr);
 
                         var partThreshold = PartMinConfidence;
                         var centroidThreshold = CentroidMinConfidence;

--- a/src/Bonsai.Sleap/PredictPoses.cs
+++ b/src/Bonsai.Sleap/PredictPoses.cs
@@ -80,7 +80,7 @@ namespace Bonsai.Sleap
                 TFSession.Runner runner = null;
                 var graph = TensorHelper.ImportModel(ModelFileName, out TFSession session);
                 var config = ConfigHelper.LoadTrainingConfig(TrainingConfig);
-                bool ragged = true;
+                var ragged = graph["Identity_6"] != null;
 
                 if (config.ModelType != ModelType.CenteredInstance)
                 {
@@ -94,7 +94,7 @@ namespace Bonsai.Sleap
                     var tensorSize = input[0].Size;
                     var batchSize = input.Length;
                     var scaleFactor = ScaleFactor;
-                    
+
                     if (scaleFactor.HasValue)
                     {
                         poseScale = scaleFactor.Value;
@@ -106,36 +106,25 @@ namespace Bonsai.Sleap
                     if (tensor == null || tensor.Shape[0] != batchSize || tensor.Shape[1] != tensorSize.Height || tensor.Shape[2] != tensorSize.Width)
                     {
                         tensor?.Dispose();
-                        try
-                        {
-                            session.GetRunner().Fetch(graph["Identity_6"][0]);
-                        }
-                        catch (Exception e)
-                        {
-                            ragged = false;
-                        }
-
                         runner = session.GetRunner();
                         tensor = TensorHelper.CreatePlaceholder(graph, runner, tensorSize, batchSize, colorChannels);
 
-                        // ragged version of the frozen graph
                         if (ragged)
                         {
+                            // ragged version of the frozen graph
                             runner.Fetch(graph["Identity"][0]);
                             runner.Fetch(graph["Identity_2"][0]);
                             runner.Fetch(graph["Identity_4"][0]);
                             runner.Fetch(graph["Identity_6"][0]);
                         }
-
-                        // unragged version of the frozen graph
-                        if (!ragged)
+                        else
                         {
+                            // unragged version of the frozen graph
                             runner.Fetch(graph["Identity"][0]);
                             runner.Fetch(graph["Identity_1"][0]);
                             runner.Fetch(graph["Identity_2"][0]);
                             runner.Fetch(graph["Identity_3"][0]);
                         }
-
                     }
 
                     var frames = Array.ConvertAll(input, frame =>
@@ -148,141 +137,71 @@ namespace Bonsai.Sleap
                     TensorHelper.UpdateTensor(tensor, colorChannels, frames);
                     var output = runner.Run();
 
+                    var shapeIdx = ragged ? 0 : 1;
                     var poseCollection = new PoseCollection(input[0]);
-                    
-                    if (!ragged)
-                    {
-                        if (output[0].Shape[1] == 0) return poseCollection;
-                        else
-                        {
-                            var centroidConfidenceTensor = output[0];
-                            float[,] centroidConfArr = new float[centroidConfidenceTensor.Shape[0], centroidConfidenceTensor.Shape[1]];
-                            centroidConfidenceTensor.GetValue(centroidConfArr);
-
-                            var centroidTensor = output[1];
-                            float[,,] centroidArr = new float[centroidTensor.Shape[0], centroidTensor.Shape[1], centroidTensor.Shape[2]];
-                            centroidTensor.GetValue(centroidArr);
-
-                            var partConfTensor = output[2];
-                            float[,,] partConfArr = new float[partConfTensor.Shape[0], partConfTensor.Shape[1], partConfTensor.Shape[2]];
-                            partConfTensor.GetValue(partConfArr);
-
-                            var poseTensor = output[3];
-                            float[,,,] poseArr = new float[poseTensor.Shape[0], poseTensor.Shape[1], poseTensor.Shape[2], poseTensor.Shape[3]];
-                            poseTensor.GetValue(poseArr);
-
-                            var partThreshold = PartMinConfidence;
-                            var centroidThreshold = CentroidMinConfidence;
-
-                            //Loop the available identifications
-                            for (int i = 0; i < centroidArr.GetLength(1); i++)
-                            {
-                                var pose = new Pose(input[0]);
-                                var centroid = new BodyPart();
-                                centroid.Name = config.AnchorName;
-                                centroid.Confidence = centroidConfArr[0, 0];
-                                if (centroid.Confidence < centroidThreshold)
-                                {
-                                    centroid.Position = new Point2f(float.NaN, float.NaN);
-                                }
-                                else
-                                {
-                                    centroid.Position = new Point2f(
-                                        x: (float)(centroidArr[0, i, 0] * poseScale),
-                                        y: (float)(centroidArr[0, i, 1] * poseScale));
-                                }
-                                pose.Centroid = centroid;
-
-                                // Iterate on the body parts
-                                for (int bodyPartIdx = 0; bodyPartIdx < poseArr.GetLength(2); bodyPartIdx++)
-                                {
-                                    var bodyPart = new BodyPart();
-                                    bodyPart.Name = config.PartNames[bodyPartIdx];
-                                    bodyPart.Confidence = partConfArr[0, i, bodyPartIdx];
-                                    if (bodyPart.Confidence < partThreshold)
-                                    {
-                                        bodyPart.Position = new Point2f(float.NaN, float.NaN);
-                                    }
-                                    else
-                                    {
-                                        bodyPart.Position = new Point2f(
-                                            x: (float)(poseArr[0, i, bodyPartIdx, 0] * poseScale),
-                                            y: (float)(poseArr[0, i, bodyPartIdx, 1] * poseScale));
-                                    }
-                                    pose.Add(bodyPart);
-                                }
-                                poseCollection.Add(pose);
-                            };
-                            return poseCollection;
-                        }
-                    }
+                    if (output[0].Shape[shapeIdx] == 0) return poseCollection;
                     else
                     {
-                        if (output[0].Shape[0] == 0) return poseCollection;
-                        else
+                        var centroidConfidenceTensor = output[0];
+                        float[] centroidConfArr = new float[centroidConfidenceTensor.Shape[shapeIdx]];
+                        centroidConfidenceTensor.GetValue(centroidConfArr);
+
+                        var centroidTensor = output[1];
+                        float[,] centroidArr = new float[centroidTensor.Shape[shapeIdx], centroidTensor.Shape[shapeIdx + 1]];
+                        centroidTensor.GetValue(centroidArr);
+
+                        var partConfTensor = output[2];
+                        float[,] partConfArr = new float[partConfTensor.Shape[shapeIdx], partConfTensor.Shape[shapeIdx + 1]];
+                        partConfTensor.GetValue(partConfArr);
+
+                        var poseTensor = output[3];
+                        float[,,] poseArr = new float[poseTensor.Shape[shapeIdx], poseTensor.Shape[shapeIdx + 1], poseTensor.Shape[shapeIdx + 2]];
+                        poseTensor.GetValue(poseArr);
+
+                        var partThreshold = PartMinConfidence;
+                        var centroidThreshold = CentroidMinConfidence;
+
+                        // Loop the available identifications
+                        for (int i = 0; i < centroidArr.GetLength(0); i++)
                         {
-                            var centroidConfidenceTensor = output[0];
-                            float[] centroidConfArr = new float[centroidConfidenceTensor.Shape[0]];
-                            centroidConfidenceTensor.GetValue(centroidConfArr);
-
-                            var centroidTensor = output[1];
-                            float[,] centroidArr = new float[centroidTensor.Shape[0], centroidTensor.Shape[1]];
-                            centroidTensor.GetValue(centroidArr);
-
-                            var partConfTensor = output[2];
-                            float[,] partConfArr = new float[partConfTensor.Shape[0], partConfTensor.Shape[1]];
-                            partConfTensor.GetValue(partConfArr);
-
-                            var poseTensor = output[3];
-                            float[,,] poseArr = new float[poseTensor.Shape[0], poseTensor.Shape[1], poseTensor.Shape[2]];
-                            poseTensor.GetValue(poseArr);
-
-                            var partThreshold = PartMinConfidence;
-                            var centroidThreshold = CentroidMinConfidence;
-
-                            //Loop the available identifications
-                            for (int i = 0; i < centroidArr.GetLength(0); i++)
+                            var pose = new Pose(input[0]);
+                            var centroid = new BodyPart();
+                            centroid.Name = config.AnchorName;
+                            centroid.Confidence = centroidConfArr[0];
+                            if (centroid.Confidence < centroidThreshold)
                             {
-                                var pose = new Pose(input[0]);
-                                var centroid = new BodyPart();
-                                centroid.Name = config.AnchorName;
-                                centroid.Confidence = centroidConfArr[0];
-                                if (centroid.Confidence < centroidThreshold)
+                                centroid.Position = new Point2f(float.NaN, float.NaN);
+                            }
+                            else
+                            {
+                                centroid.Position = new Point2f(
+                                    x: (float)(centroidArr[i, 0] * poseScale),
+                                    y: (float)(centroidArr[i, 1] * poseScale));
+                            }
+                            pose.Centroid = centroid;
+
+                            // Iterate on the body parts
+                            for (int bodyPartIdx = 0; bodyPartIdx < poseArr.GetLength(1); bodyPartIdx++)
+                            {
+                                var bodyPart = new BodyPart();
+                                bodyPart.Name = config.PartNames[bodyPartIdx];
+                                bodyPart.Confidence = partConfArr[i, bodyPartIdx];
+                                if (bodyPart.Confidence < partThreshold)
                                 {
-                                    centroid.Position = new Point2f(float.NaN, float.NaN);
+                                    bodyPart.Position = new Point2f(float.NaN, float.NaN);
                                 }
                                 else
                                 {
-                                    centroid.Position = new Point2f(
-                                        x: (float)(centroidArr[i, 0] * poseScale),
-                                        y: (float)(centroidArr[i, 1] * poseScale));
+                                    bodyPart.Position = new Point2f(
+                                        x: (float)(poseArr[i, bodyPartIdx, 0] * poseScale),
+                                        y: (float)(poseArr[i, bodyPartIdx, 1] * poseScale));
                                 }
-                                pose.Centroid = centroid;
-
-                                // Iterate on the body parts
-                                for (int bodyPartIdx = 0; bodyPartIdx < poseArr.GetLength(1); bodyPartIdx++)
-                                {
-                                    var bodyPart = new BodyPart();
-                                    bodyPart.Name = config.PartNames[bodyPartIdx];
-                                    bodyPart.Confidence = partConfArr[i, bodyPartIdx];
-                                    if (bodyPart.Confidence < partThreshold)
-                                    {
-                                        bodyPart.Position = new Point2f(float.NaN, float.NaN);
-                                    }
-                                    else
-                                    {
-                                        bodyPart.Position = new Point2f(
-                                            x: (float)(poseArr[i, bodyPartIdx, 0] * poseScale),
-                                            y: (float)(poseArr[i, bodyPartIdx, 1] * poseScale));
-                                    }
-                                    pose.Add(bodyPart);
-                                }
-                                poseCollection.Add(pose);
-                            };
-                            return poseCollection;
-                        }
+                                pose.Add(bodyPart);
+                            }
+                            poseCollection.Add(pose);
+                        };
+                        return poseCollection;
                     }
-                    
                 });
             });
         }

--- a/src/Bonsai.Sleap/TensorHelper.cs
+++ b/src/Bonsai.Sleap/TensorHelper.cs
@@ -1,6 +1,7 @@
 ﻿using OpenCV.Net;
 using System;
 using System.IO;
+using System.Runtime.InteropServices;
 using TensorFlow;
 
 namespace Bonsai.Sleap
@@ -131,6 +132,19 @@ namespace Bonsai.Sleap
                 }
                 return result;
             }
+        }
+
+        public static unsafe void GetTensorValue(TFTensor tensor, Array array)
+        {
+            var elementType = array.GetType().GetElementType();
+            tensor.CheckDataTypeAndSize(elementType, array.Length);
+            var gCHandle = GCHandle.Alloc(array, GCHandleType.Pinned);
+            try
+            {
+                var num = tensor.TensorByteSize.ToUInt64();
+                Buffer.MemoryCopy(tensor.Data.ToPointer(), gCHandle.AddrOfPinnedObject().ToPointer(), num, num);
+            }
+            finally { gCHandle.Free(); }
         }
     }
 }


### PR DESCRIPTION
While trying to import the frozen graphs from SLEAP, there is an issue where an Object reference error that pops up when you import. This is due to the default in the previous versions (< 1.3) of SLEAP had ragged tensors, while it is by default unragged tensors for versions > 1.3.

So to fix this, I have modified the code to read the correct tensor with the correct shapes.

This potentially could solve this issue https://github.com/talmolab/sleap/issues/1542

But there is a need to store more metadata to distinguish reading the ragged tensors from unragged tensors, for a future enhancement in SLEAP
