### PR TITLE
Return all identity scores for each instance

### DIFF
--- a/src/Bonsai.Sleap.Design/Bonsai.Sleap.Design.csproj
+++ b/src/Bonsai.Sleap.Design/Bonsai.Sleap.Design.csproj
@@ -6,11 +6,11 @@
     <PackageTags>Bonsai Rx SLEAP LEAP Markerless Multi Pose Tracking Visualizers</PackageTags>
     <TargetFramework>net472</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
-    <VersionPrefix>0.2.0</VersionPrefix>
+    <VersionPrefix>0.3.0</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bonsai.Vision.Design" Version="2.7.0" />
+    <PackageReference Include="Bonsai.Vision.Design" Version="2.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Bonsai.Sleap/Bonsai.Sleap.csproj
+++ b/src/Bonsai.Sleap/Bonsai.Sleap.csproj
@@ -6,7 +6,7 @@
     <PackageTags>Bonsai Rx SLEAP LEAP Markerless Multi Pose Tracking</PackageTags>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TargetFramework>net472</TargetFramework>
-    <VersionPrefix>0.2.2</VersionPrefix>
+    <VersionPrefix>0.3.0</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Bonsai.Sleap/PoseIdentity.cs
+++ b/src/Bonsai.Sleap/PoseIdentity.cs
@@ -20,19 +20,25 @@ namespace Bonsai.Sleap
         }
 
         /// <summary>
-        /// Gets or sets the predicted pose identity.
+        /// Gets or sets the maximum likelihood predicted pose identity.
         /// </summary>
         public string Identity { get; set; }
 
         /// <summary>
-        /// Gets or sets the predicted pose identity index.
+        /// Gets or sets the maximum likelihood confidence score for the predicted identity.
+        /// </summary>
+        public float Confidence { get; set; }
+
+        /// <summary>
+        /// Gets or sets the maximum likelihood predicted pose identity index.
         /// </summary>
         [XmlIgnore]
         public int IdentityIndex { get; set; }
 
         /// <summary>
-        /// Gets or sets the confidence score for the predicted identity.
+        /// Gets or sets the predicted identity confidence scores for this instance.
         /// </summary>
-        public float Confidence { get; set; }
+        [XmlIgnore]
+        public float[] IdentityScores { get; set; }
     }
 }

--- a/src/Bonsai.Sleap/PredictPoseIdentities.cs
+++ b/src/Bonsai.Sleap/PredictPoseIdentities.cs
@@ -184,7 +184,7 @@ namespace Bonsai.Sleap
                         {
                             // Find the class with max score
                             var pose = new PoseIdentity(input.Length == 1 ? input[0] : input[iid]);
-                            var maxIndex = ArgMax(idArr, iid, Comparer<float>.Default, out float maxScore, out float[] scores);
+                            pose.IdentityScores = GetRowValues(idArr, iid, Comparer<float>.Default, out float maxScore, out int maxIndex);
 
                             if (maxScore < idThreshold || maxIndex < 0)
                             {
@@ -257,29 +257,29 @@ namespace Bonsai.Sleap
             return Process(source.Select(frame => new IplImage[] { frame }));
         }
 
-        static int ArgMax<TElement>(
+        static TElement[] GetRowValues<TElement>(
             TElement[,] array,
-            int instance,
+            int rowIndex,
             IComparer<TElement> comparer,
             out TElement maxValue,
-            out TElement[] values)
+            out int maxIndex)
         {
             if (array == null) throw new ArgumentNullException(nameof(array));
             if (comparer == null) throw new ArgumentNullException(nameof(comparer));
 
-            int maxIndex = -1;
+            maxIndex = -1;
             maxValue = default;
-            values = new TElement[array.GetLength(1)];
+            var values = new TElement[array.GetLength(1)];
             for (int i = 0; i < values.Length; i++)
             {
-                values[i] = array[instance, i];
+                values[i] = array[rowIndex, i];
                 if (i == 0 || comparer.Compare(values[i], maxValue) > 0)
                 {
                     maxIndex = i;
-                    maxValue = array[instance, i];
+                    maxValue = array[rowIndex, i];
                 }
             }
-            return maxIndex;
+            return values;
         }
     }
 }

--- a/src/Bonsai.Sleap/PredictPoseIdentities.cs
+++ b/src/Bonsai.Sleap/PredictPoseIdentities.cs
@@ -184,7 +184,7 @@ namespace Bonsai.Sleap
                         {
                             // Find the class with max score
                             var pose = new PoseIdentity(input.Length == 1 ? input[0] : input[iid]);
-                            var maxIndex = ArgMax(idArr, iid, Comparer<float>.Default, out float maxScore);
+                            var maxIndex = ArgMax(idArr, iid, Comparer<float>.Default, out float maxScore, out float[] scores);
 
                             if (maxScore < idThreshold || maxIndex < 0)
                             {
@@ -257,16 +257,23 @@ namespace Bonsai.Sleap
             return Process(source.Select(frame => new IplImage[] { frame }));
         }
 
-        static int ArgMax<TElement>(TElement[,] array, int instance, IComparer<TElement> comparer, out TElement maxValue)
+        static int ArgMax<TElement>(
+            TElement[,] array,
+            int instance,
+            IComparer<TElement> comparer,
+            out TElement maxValue,
+            out TElement[] values)
         {
             if (array == null) throw new ArgumentNullException(nameof(array));
             if (comparer == null) throw new ArgumentNullException(nameof(comparer));
 
             int maxIndex = -1;
             maxValue = default;
-            for (int i = 0; i < array.GetLength(1); i++)
+            values = new TElement[array.GetLength(1)];
+            for (int i = 0; i < values.Length; i++)
             {
-                if (i == 0 || comparer.Compare(array[instance, i], maxValue) > 0)
+                values[i] = array[instance, i];
+                if (i == 0 || comparer.Compare(values[i], maxValue) > 0)
                 {
                     maxIndex = i;
                     maxValue = array[instance, i];


### PR DESCRIPTION
Currently the `PoseIdentity` class returns only the identity and confidence score for the identity class with maximum likelihood. This PR includes the full vector of identity confidence scores to allow more sophisticated downstream filtering and processing of SLEAP output.

Fixes #18 