### PR TITLE
Add model metadata to pose result objects

### DIFF
--- a/src/Bonsai.Sleap.Design/Properties/launchSettings.json
+++ b/src/Bonsai.Sleap.Design/Properties/launchSettings.json
@@ -2,8 +2,9 @@
   "profiles": {
     "Bonsai": {
       "commandName": "Executable",
-      "executablePath": "$(registry:HKEY_CURRENT_USER\\Software\\Goncalo Lopes\\Bonsai@InstallDir)Bonsai.exe",
-      "commandLineArgs": "--lib:$(TargetDir)."
+      "executablePath": "$(registry:HKEY_CURRENT_USER\\Software\\Bonsai Foundation\\Bonsai@InstallDir)Bonsai.exe",
+      "commandLineArgs": "--lib:\"$(TargetDir).\"",
+      "nativeDebugging": true
     }
   }
 }

--- a/src/Bonsai.Sleap/GetMaximumConfidencePoseIdentity.cs
+++ b/src/Bonsai.Sleap/GetMaximumConfidencePoseIdentity.cs
@@ -52,18 +52,18 @@ namespace Bonsai.Sleap
                     }
                 }
 
-                return maxIndex < 0 ? DefaultPose(poses.Image, identity) : poses[maxIndex];
+                return maxIndex < 0 ? DefaultPose(poses.Image, identity, poses.Model) : poses[maxIndex];
             });
         }
 
-        static PoseIdentity DefaultPose(IplImage image, string identity)
+        static PoseIdentity DefaultPose(IplImage image, string identity, IModelInfo model)
         {
-            return new PoseIdentity(image)
+            return new PoseIdentity(image, model)
             {
                 IdentityIndex = -1,
                 Identity = identity,
                 Confidence = float.NaN,
-                Centroid = GetBodyPart.DefaultBodyPart(string.Empty)
+                Centroid = GetBodyPart.DefaultBodyPart(model.AnchorName)
             };
         }
     }

--- a/src/Bonsai.Sleap/IModelInfo.cs
+++ b/src/Bonsai.Sleap/IModelInfo.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections.Generic;
+
+namespace Bonsai.Sleap
+{
+    /// <summary>
+    /// Provides information about the model used for inference.
+    /// </summary>
+    public interface IModelInfo
+    {
+        /// <summary>
+        /// Gets the type of SLEAP model used for inference.
+        /// </summary>
+        ModelType ModelType { get; }
+
+        /// <summary>
+        /// Gets the name of the anchor part.
+        /// </summary>
+        string AnchorName { get; }
+
+        /// <summary>
+        /// Gets the collection of body part names.
+        /// </summary>
+        IReadOnlyList<string> PartNames { get; }
+
+        /// <summary>
+        /// Gets the collection of class names used to assign pose identities.
+        /// </summary>
+        IReadOnlyList<string> ClassNames { get; }
+    }
+}

--- a/src/Bonsai.Sleap/ModelType.cs
+++ b/src/Bonsai.Sleap/ModelType.cs
@@ -1,12 +1,38 @@
 ﻿namespace Bonsai.Sleap
 {
-    internal enum ModelType
+    /// <summary>
+    /// Specifies the type of SLEAP model.
+    /// </summary>
+    public enum ModelType
     {
+        /// <summary>
+        /// A model type which is unsupported by this package.
+        /// </summary>
         InvalidModel = 0,
+
+        /// <summary>
+        /// A model for single instance pose estimation.
+        /// </summary>
         SingleInstance = 1,
+
+        /// <summary>
+        /// A model for centroid-only pose estimation.
+        /// </summary>
         Centroid = 2,
+
+        /// <summary>
+        /// A model for centered instance pose estimation.
+        /// </summary>
         CenteredInstance = 3,
+
+        /// <summary>
+        /// A model for multi instance pose estimation.
+        /// </summary>
         MultiInstance = 4,
+
+        /// <summary>
+        /// A model for multi-class multi-instance pose estimation.
+        /// </summary>
         MultiClass = 5
     }
 }

--- a/src/Bonsai.Sleap/Pose.cs
+++ b/src/Bonsai.Sleap/Pose.cs
@@ -13,15 +13,22 @@ namespace Bonsai.Sleap
         /// extracted from the specified image.
         /// </summary>
         /// <param name="image">The image from which the pose was extracted.</param>
-        public Pose(IplImage image)
+        /// <param name="model">Information about the model used to extract the pose.</param>
+        public Pose(IplImage image, IModelInfo model)
         {
             Image = image;
+            Model = model;
         }
 
         /// <summary>
         /// Gets the image from which the pose was extracted.
         /// </summary>
         public IplImage Image { get; }
+
+        /// <summary>
+        /// Gets information about the model used to extract the pose.
+        /// </summary>
+        public IModelInfo Model { get; }
 
         /// <summary>
         /// Gets or sets the center point used for cropping. 

--- a/src/Bonsai.Sleap/PoseCollection.cs
+++ b/src/Bonsai.Sleap/PoseCollection.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.ObjectModel;
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using OpenCV.Net;
 
 namespace Bonsai.Sleap
@@ -13,14 +14,21 @@ namespace Bonsai.Sleap
         /// extracted from the specified image.
         /// </summary>
         /// <param name="image">The image from which the poses were extracted.</param>
-        public PoseCollection(IplImage image)
+        /// <param name="model">Information about the model used to extract the poses.</param>
+        public PoseCollection(IplImage image, IModelInfo model)
         {
             Image = image;
+            Model = model;
         }
 
         /// <summary>
         /// Gets the image from which the poses were extracted.
         /// </summary>
         public IplImage Image { get; }
+
+        /// <summary>
+        /// Gets information about the model used to extract the poses.
+        /// </summary>
+        public IModelInfo Model { get; }
     }
 }

--- a/src/Bonsai.Sleap/PoseIdentity.cs
+++ b/src/Bonsai.Sleap/PoseIdentity.cs
@@ -14,8 +14,9 @@ namespace Bonsai.Sleap
         /// extracted from the specified image.
         /// </summary>
         /// <param name="image">The image from which the pose identity was extracted.</param>
-        public PoseIdentity(IplImage image)
-            : base(image)
+        /// <param name="model">Information about the model used to extract the pose identity.</param>
+        public PoseIdentity(IplImage image, IModelInfo model)
+            : base(image, model)
         {
         }
 

--- a/src/Bonsai.Sleap/PoseIdentityCollection.cs
+++ b/src/Bonsai.Sleap/PoseIdentityCollection.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.ObjectModel;
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using OpenCV.Net;
 
 namespace Bonsai.Sleap
@@ -13,15 +14,22 @@ namespace Bonsai.Sleap
         /// extracted from the specified image.
         /// </summary>
         /// <param name="image">The image from which the pose identities were extracted.</param>
-        public PoseIdentityCollection(IplImage image)
+        /// <param name="model">Information about the model used to extract the pose identities.</param>
+        public PoseIdentityCollection(IplImage image, IModelInfo model)
         {
             Image = image;
+            Model = model;
         }
 
         /// <summary>
         /// Gets the image from which the pose identities were extracted.
         /// </summary>
         public IplImage Image { get; }
+
+        /// <summary>
+        /// Gets information about the model used to extract the pose identities.
+        /// </summary>
+        public IModelInfo Model { get; }
     }
 
 }

--- a/src/Bonsai.Sleap/PredictPoseIdentities.cs
+++ b/src/Bonsai.Sleap/PredictPoseIdentities.cs
@@ -151,7 +151,7 @@ namespace Bonsai.Sleap
                     var output = runner.Run();
 
                     var shapeIdx = ragged ? 0 : 1;
-                    var identityCollection = new PoseIdentityCollection(input[0]);
+                    var identityCollection = new PoseIdentityCollection(input[0], config);
                     if (output[0].Shape[shapeIdx] == 0) return identityCollection;
                     else
                     {
@@ -183,7 +183,7 @@ namespace Bonsai.Sleap
                         for (int iid = 0; iid < idArr.GetLength(0); iid++)
                         {
                             // Find the class with max score
-                            var pose = new PoseIdentity(input.Length == 1 ? input[0] : input[iid]);
+                            var pose = new PoseIdentity(input.Length == 1 ? input[0] : input[iid], config);
                             pose.IdentityScores = GetRowValues(idArr, iid, Comparer<float>.Default, out float maxScore, out int maxIndex);
 
                             if (maxScore < idThreshold || maxIndex < 0)

--- a/src/Bonsai.Sleap/PredictPoses.cs
+++ b/src/Bonsai.Sleap/PredictPoses.cs
@@ -138,7 +138,7 @@ namespace Bonsai.Sleap
                     var output = runner.Run();
 
                     var shapeIdx = ragged ? 0 : 1;
-                    var poseCollection = new PoseCollection(input[0]);
+                    var poseCollection = new PoseCollection(input[0], config);
                     if (output[0].Shape[shapeIdx] == 0) return poseCollection;
                     else
                     {
@@ -164,7 +164,7 @@ namespace Bonsai.Sleap
                         // Loop the available identifications
                         for (int i = 0; i < centroidArr.GetLength(0); i++)
                         {
-                            var pose = new Pose(input[0]);
+                            var pose = new Pose(input[0], config);
                             var centroid = new BodyPart();
                             centroid.Name = config.AnchorName;
                             centroid.Confidence = centroidConfArr[0];

--- a/src/Bonsai.Sleap/PredictSinglePose.cs
+++ b/src/Bonsai.Sleap/PredictSinglePose.cs
@@ -136,7 +136,7 @@ namespace Bonsai.Sleap
                     //Loop the available identifications
                     for (int i = 0; i < input.Length; i++)
                     {
-                        var pose = new Pose(input[i]);
+                        var pose = new Pose(input[i], config);
                         // Iterate on the body parts
                         for (int bodyPartIdx = 0; bodyPartIdx < poseArr.GetLength(2); bodyPartIdx++)
                         {

--- a/src/Bonsai.Sleap/TrainingConfig.cs
+++ b/src/Bonsai.Sleap/TrainingConfig.cs
@@ -3,7 +3,7 @@ using OpenCV.Net;
 
 namespace Bonsai.Sleap
 {
-    internal class TrainingConfig
+    internal class TrainingConfig : IModelInfo
     {
         public ModelType ModelType { get; set; }
 
@@ -13,12 +13,15 @@ namespace Bonsai.Sleap
 
         public List<string> ClassNames { get; } = new List<string>();
 
+        IReadOnlyList<string> IModelInfo.PartNames => PartNames;
+
+        IReadOnlyList<string> IModelInfo.ClassNames => ClassNames;
+
         public Skeleton Skeleton { get; set; }
 
         public Size TargetSize { get; set; }
 
         public float InputScaling { get; set; } = float.NaN;
-
     }
 
     internal class Skeleton


### PR DESCRIPTION
To improve downstream processing and visualization we often require information about the model used to perform inference. This allows extracting names of body parts (even if they were not seen), class labels, and anchors. In the future we may include the skeleton for aiding in visualization.

Downstream operators were updated to ensure metadata is preserved throughout.