### PR TITLE
Ensure default pose contains default body parts

### DIFF
--- a/src/Bonsai.Sleap/GetBodyPart.cs
+++ b/src/Bonsai.Sleap/GetBodyPart.cs
@@ -44,7 +44,7 @@ namespace Bonsai.Sleap
             {
                 Name = name,
                 Position = new Point2f(float.NaN, float.NaN),
-                Confidence = 0
+                Confidence = float.NaN
             };
         }
     }

--- a/src/Bonsai.Sleap/GetMaximumConfidencePoseIdentity.cs
+++ b/src/Bonsai.Sleap/GetMaximumConfidencePoseIdentity.cs
@@ -58,13 +58,21 @@ namespace Bonsai.Sleap
 
         static PoseIdentity DefaultPose(IplImage image, string identity, IModelInfo model)
         {
-            return new PoseIdentity(image, model)
+            var pose = new PoseIdentity(image, model)
             {
-                IdentityIndex = -1,
                 Identity = identity,
                 Confidence = float.NaN,
+                IdentityIndex = -1,
+                IdentityScores = new float[model.ClassNames.Count],
                 Centroid = GetBodyPart.DefaultBodyPart(model.AnchorName)
             };
+
+            foreach (var partName in model.PartNames)
+            {
+                pose.Add(GetBodyPart.DefaultBodyPart(partName));
+            }
+
+            return pose;
         }
     }
 }


### PR DESCRIPTION
Default pose values are meant to retain all the same structure of a valid pose for a given model. However, the current implementation of `GetMaximumConfidencePoseIdentity` did not make use of information about the model, and thus did not retain the structure of body parts and identity scores.

This PR rectifies the situation by assigning default body part values according to the model metadata provided in the pose identity input.