### PR TITLE
Add specialized collection class for matching

### DIFF
--- a/src/Bonsai.Sleap/FindPoseIdentityMatching.cs
+++ b/src/Bonsai.Sleap/FindPoseIdentityMatching.cs
@@ -17,7 +17,7 @@ namespace Bonsai.Sleap
     /// </remarks>
     [WorkflowElementCategory(ElementCategory.Transform)]
     [Description("Returns a collection of poses where each distinct identity class has been matched to a single high confidence pose.")]
-    public class FindPoseIdentityMatching : Transform<PoseIdentityCollection, PoseIdentityCollection>
+    public class FindPoseIdentityMatching : Transform<PoseIdentityCollection, PoseIdentityMatching>
     {
         /// <summary>
         /// Gets or sets a value specifying the minimum confidence value used to match an identity
@@ -40,10 +40,10 @@ namespace Bonsai.Sleap
         /// for each distinct model class.
         /// </param>
         /// <returns>
-        /// A sequence of <see cref="PoseIdentityCollection"/> objects representing
+        /// A sequence of <see cref="PoseIdentityMatching"/> objects representing
         /// the poses matched to each distinct model class.
         /// </returns>
-        public override IObservable<PoseIdentityCollection> Process(IObservable<PoseIdentityCollection> source)
+        public override IObservable<PoseIdentityMatching> Process(IObservable<PoseIdentityCollection> source)
         {
             return source.Select(poses =>
             {
@@ -51,7 +51,7 @@ namespace Bonsai.Sleap
                 var identityThreshold = IdentityMinConfidence;
                 var matchedPoses = new HashSet<PoseIdentity>();
                 var bestPoses = new PoseIdentity[model.ClassNames.Count];
-                var result = new PoseIdentityCollection(poses.Image, model);
+                var result = new PoseIdentityMatching(poses.Image, model);
 
                 static float GetMaxConfidence(PoseIdentity pose, PoseIdentity[] bestPoses, out int maxClass)
                 {

--- a/src/Bonsai.Sleap/PoseIdentityCollection.cs
+++ b/src/Bonsai.Sleap/PoseIdentityCollection.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
 using OpenCV.Net;
 
 namespace Bonsai.Sleap

--- a/src/Bonsai.Sleap/PoseIdentityMatching.cs
+++ b/src/Bonsai.Sleap/PoseIdentityMatching.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using OpenCV.Net;
+
+namespace Bonsai.Sleap
+{
+    /// <summary>
+    /// Represents a collection of identity classes matched to poses extracted from a
+    /// specified image.
+    /// </summary>
+    public class PoseIdentityMatching : PoseIdentityCollection
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PoseIdentityMatching"/> class
+        /// extracted from the specified image.
+        /// </summary>
+        /// <inheritdoc/>
+        public PoseIdentityMatching(IplImage image, IModelInfo model)
+            : base(image, model)
+        {
+        }
+
+        /// <summary>
+        /// Gets the pose identity matching the specified class label.
+        /// </summary>
+        /// <param name="key">
+        /// The label of the identity class to get.
+        /// </param>
+        /// <returns>
+        /// The pose identity matching the specified class label. If a pose identity
+        /// matching the specified key is not found, an exception is thrown.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="key"/> is null.
+        /// </exception>
+        /// <exception cref="KeyNotFoundException">
+        /// A pose identity matching the specified <paramref name="key"/>
+        /// does not exist in the collection.
+        /// </exception>
+        public PoseIdentity this[string key]
+        {
+            get
+            {
+                if (key == null)
+                {
+                    throw new ArgumentNullException(nameof(key));
+                }
+
+                foreach (var item in Items)
+                {
+                    if (item.Identity == key)
+                    {
+                        return item;
+                    }
+                }
+
+                throw new KeyNotFoundException();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Following the pose identity matching features introduced in #24, this PR introduces a specialized collection to represent the matching result. The main additional feature is the ability to get the matching by identity class label, which allows the use of the built-in `Index` operator with a `string` key:

<img alt="image" src="https://github.com/bonsai-rx/sleap/assets/5315880/e2a85eaa-c546-4e29-a727-769235a6ee4e" height="75px" />
